### PR TITLE
Turn `packages-dir` param into `packages_dir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ would now look like:
   with:
     user: __token__
     password: ${{ secrets.pypi_password }}
-    packages-dir: custom-dir/
+    packages_dir: custom-dir/
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   repository_url:
     description: The repository URL to use
     required: false
-  packages-dir:
+  packages_dir:
     description: The target directory for distribution
     required: false
     default: dist
@@ -26,4 +26,4 @@ runs:
   - ${{ inputs.user }}
   - ${{ inputs.password }}
   - ${{ inputs.repository_url }}
-  - ${{ inputs.packages-dir }}
+  - ${{ inputs.packages_dir }}


### PR DESCRIPTION
d7872a6165 changed the name of an input from `dist` to `packages-dir`,
but unfortunately it looks like GitHub actions expect underscores rather
than dashes, so deploys are currently broken with the following errors:

```
Run pypa/gh-action-pypi-publish@master
  with:
    user: __token__
    password: ***
    packages-dir: dist
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.0/x64
/usr/bin/docker run --name [...] -e INPUT_PACKAGES-DIR [...]

/app/twine-upload.sh: line 22: INPUT_PACKAGES_DIR: unbound variable
```

This patch replaces the dash with an underscore.

Resolves #20