### PR TITLE
Fixed Example of Triggering on Tag Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ filter to the step:
 
 
 ```yml
-  if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+  if: github.event_name == 'create' && github.event.ref_type == 'tag'
 ```
 
 So the full step would look like:
 
 
 ```yml
+on:
+  create:
+
 - name: Publish package
-  if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+  if: github.event_name == 'create' && github.event.ref_type == 'tag'
   uses: pypa/gh-action-pypi-publish@master
   with:
     user: __token__

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ So the full step would look like:
 on:
   create:
 
-- name: Publish package
-  if: github.event_name == 'create' && github.event.ref_type == 'tag'
-  uses: pypa/gh-action-pypi-publish@master
-  with:
-    user: __token__
-    password: ${{ secrets.pypi_password }}
+jobs:
+  steps:
+    - name: Publish package
+      if: github.event_name == 'create' && github.event.ref_type == 'tag'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
 ```
 
 The example above uses the new [API token](https://pypi.org/help/#apitoken)


### PR DESCRIPTION
Thank you for creating this Github Action!

I was not able to trigger this action following the README example of a tagged commit. Maybe I was misunderstanding the documentation, but I'm have been using the following remote tag creation commands.

```bash
git push origin <tag-name> # or
git push --follow-tags
```

I was not able to find documentation on "startsWith(github.event.ref, 'refs/tags')" for filtering tag creation. Instead, Github's [webhook documentation](https://developer.github.com/v3/activity/events/types/#createevent) is saying a tag/branch creation will trigger the CreateEvent. I was able to get this action triggered by adding "on: create" and filter "ref_type" to be "tag". A working action run can be seen [here](https://github.com/cmusatyalab/OpenWorkflow/runs/604264301?check_suite_focus=true).

This pull request modifies the example of a tagged commit accordingly.