### PR TITLE
feat: Add twine check before upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ would now look like:
     packages_dir: custom-dir/
 ```
 
+### Disabling twine check
+
+You can also disable the twine check with:
+
+```yml
+   with:
+     check: false
+```
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project

--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ would now look like:
     packages_dir: custom-dir/
 ```
 
-### Disabling twine check
+### Disabling metadata verification
 
-You can also disable the twine check with:
+It is recommended that you run `twine check` just after producing your files,
+but this also runs `twine check` before upload. You can also disable the twine
+check with:
 
 ```yml
    with:
-     check: false
+     verify_metadata: false
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,8 @@ inputs:
     description: The target directory for distribution
     required: false
     default: dist
-  check:
-    description: Check before uploading
+  verify_metadata:
+    description: Check metadata before uploading
     required: false
     default: true
 branding:
@@ -31,4 +31,4 @@ runs:
   - ${{ inputs.password }}
   - ${{ inputs.repository_url }}
   - ${{ inputs.packages_dir }}
-  - ${{ inputs.check }}
+  - ${{ inputs.verify_metadata }}

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: The target directory for distribution
     required: false
     default: dist
+  check:
+    description: Check before uploading
+    required: false
+    default: true
 branding:
   color: yellow
   icon: upload-cloud
@@ -27,3 +31,4 @@ runs:
   - ${{ inputs.password }}
   - ${{ inputs.repository_url }}
   - ${{ inputs.packages_dir }}
+  - ${{ inputs.check }}

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -28,6 +28,10 @@ then
         are in place should you face this problem.
 fi
 
+if [[ ${INPUT_CHECK,,} != "false" ]] ; then
+  exec twine check ${INPUT_PACKAGES_DIR%%/}/*
+fi
+
 
 TWINE_USERNAME="$INPUT_USER" \
 TWINE_PASSWORD="$INPUT_PASSWORD" \

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -28,7 +28,7 @@ then
         are in place should you face this problem.
 fi
 
-if [[ ${INPUT_CHECK,,} != "false" ]] ; then
+if [[ ${INPUT_VERIFY_METADATA,,} != "false" ]] ; then
   twine check ${INPUT_PACKAGES_DIR%%/}/*
 fi
 

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -29,7 +29,7 @@ then
 fi
 
 if [[ ${INPUT_CHECK,,} != "false" ]] ; then
-  exec twine check ${INPUT_PACKAGES_DIR%%/}/*
+  twine check ${INPUT_PACKAGES_DIR%%/}/*
 fi
 
 


### PR DESCRIPTION
Closes #30.

This is probably roughly correct, but haven't come up with a good way to test it yet. Possibly @webknjaz might have an idea / be able to test it?

Docs *could* suggest that twine check be added post build too, to exit sooner, but some of the manylinux2014 special arch images don't even have access to twine, so it can't always be used easily, and this action is not supposed to do anything for building, just uploading.