### PR TITLE
Allow wildcards in INPUT_PACKAGES_DIR

### DIFF
--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -18,10 +18,8 @@ then
         copied your token properly if such an error occurs.
 fi
 
-if [[
-    ! -d ${INPUT_PACKAGES_DIR%%/}/ ||
-    "`ls -l ${INPUT_PACKAGES_DIR%%/}/*.tar.gz ${INPUT_PACKAGES_DIR%%/}/*.whl`" == "total 0"
-  ]]
+if ( ! ls -A ${INPUT_PACKAGES_DIR%%/}/*.tar.gz &> /dev/null && \
+     ! ls -A ${INPUT_PACKAGES_DIR%%/}/*.whl &> /dev/null )
 then
     echo \
         ::warning file='# >>' PyPA publish to PyPI GHA'%3A' \


### PR DESCRIPTION
Removed the string comparison and replaced it by checking for the return code of `ls`.
`ls` will return code `2` if either the folder does not exist or if no files can be found with the specified wildcards.


### Examples

Assuming that `INPUT_PACKAGES_DIR="/tmp/tmp.P4rb84COwM/*/"` has a wildcard.

#### The following examples will trigger the warning
1. Folder `/tmp/tmp.P4rb84COwM/` does not exist
1. ```
   /tmp/tmp.P4rb84COwM/
   ├── a/
   └── b/
    ```
1. ```
    /tmp/tmp.P4rb84COwM/
    ├── a/
    │   └── a.tar.gz
    └── b/
    ```
1. ```
    /tmp/tmp.P4rb84COwM
    ├── a/
    └── b/
        └── b.whl
    ```
1. Due to the wildcard, this is also not allowed
    ```
    /tmp/tmp.P4rb84COwM
    ├── c.tar.gz
    └── c.whl
    ```
    
#### The following examples will NOT trigger the warning
1. ```
    /tmp/tmp.P4rb84COwM/
    ├── a
    │   └── a.tar.gz
    └── b/
        └── b.whl
    ```
1. ```
    /tmp/tmp.P4rb84COwM/
    ├── b
    │   └── b.whl
    └── c
        ├── c.tar.gz
        └── c.whl
    ```
  

Fixes #34 