### PR TITLE
docs: pin to tagged version in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use the action add the following step to your workflow file (e.g.
 
 ```yml
 - name: Publish a Python distribution to PyPI
-  uses: pypa/gh-action-pypi-publish@release/v1
+  uses: pypa/gh-action-pypi-publish@v1.4.2
   with:
     user: __token__
     password: ${{ secrets.PYPI_API_TOKEN }}
@@ -39,7 +39,7 @@ So the full step would look like:
 ```yml
 - name: Publish package
   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-  uses: pypa/gh-action-pypi-publish@release/v1
+  uses: pypa/gh-action-pypi-publish@v1.4.2
   with:
     user: __token__
     password: ${{ secrets.PYPI_API_TOKEN }}
@@ -101,7 +101,7 @@ You'll need to create another token for a separate host and then
 The action invocation in this case would look like:
 ```yml
 - name: Publish package to TestPyPI
-  uses: pypa/gh-action-pypi-publish@release/v1
+  uses: pypa/gh-action-pypi-publish@v1.4.2
   with:
     user: __token__
     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -116,7 +116,7 @@ would now look like:
 
 ```yml
 - name: Publish package to PyPI
-  uses: pypa/gh-action-pypi-publish@release/v1
+  uses: pypa/gh-action-pypi-publish@v1.4.2
   with:
     user: __token__
     password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
While there has been a prior PR trying to update the README examples to pin to a tagged version following the recommendations given. I believe that with the way it's written, it's still pointing to a branch instead of an actual tagged version.

I have updated the examples to pin to an actual tagged version `v1.4.2` so that the examples can be used as is without things breaking *and* still following the recommendations