### PR TITLE
Remove quotes in the argument of `python /app/print-hash.py`

### DIFF
--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -45,7 +45,7 @@ if [[ ${INPUT_VERBOSE,,} != "false" ]] ; then
 fi
 
 if [[ ${INPUT_PRINT_HASH,,} != "false" || ${INPUT_VERBOSE,,} != "false" ]] ; then
-    python /app/print-hash.py "${INPUT_PACKAGES_DIR%%/}"
+    python /app/print-hash.py ${INPUT_PACKAGES_DIR%%/}
 fi
 
 TWINE_USERNAME="$INPUT_USER" \


### PR DESCRIPTION
Fix #90