### PR TITLE
🎨 Convert action inputs to use kebab-case

### DIFF
--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -91,7 +91,7 @@ jobs:
       with:
         user: ${{ env.devpi-username }}
         password: ${{ env.devpi-password }}
-        repository_url: >-
+        repository-url: >-
           http://devpi:${{ env.devpi-port }}/${{ env.devpi-username }}/public/
 
 ...

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ project's specific needs.
 For example, you could implement a parallel workflow that
 pushes every commit to TestPyPI or your own index server,
 like `devpi`. For this, you'd need to (1) specify a custom
-`repository_url` value and (2) generate a unique version
+`repository-url` value and (2) generate a unique version
 number for each upload so that they'd not create a conflict.
 The latter is possible if you use `setuptools_scm` package but
 you could also invent your own solution based on the distance
@@ -114,7 +114,7 @@ The action invocation in this case would look like:
   uses: pypa/gh-action-pypi-publish@release/v1
   with:
     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    repository_url: https://test.pypi.org/legacy/
+    repository-url: https://test.pypi.org/legacy/
 ```
 
 ### Customizing target package dists directory
@@ -128,7 +128,7 @@ would now look like:
   uses: pypa/gh-action-pypi-publish@release/v1
   with:
     password: ${{ secrets.PYPI_API_TOKEN }}
-    packages_dir: custom-dir/
+    packages-dir: custom-dir/
 ```
 
 ### Disabling metadata verification
@@ -139,7 +139,7 @@ check with:
 
 ```yml
    with:
-     verify_metadata: false
+     verify-metadata: false
 ```
 
 ### Tolerating release package file duplicates
@@ -149,12 +149,12 @@ may hit race conditions. For example, when publishing from multiple CIs
 or even having workflows with the same steps triggered within GitHub
 Actions CI/CD for different events concerning the same high-level act.
 
-To facilitate this use-case, you may use `skip_existing` (disabled by
+To facilitate this use-case, you may use `skip-existing` (disabled by
 default) setting as follows:
 
 ```yml
    with:
-     skip_existing: true
+     skip-existing: true
 ```
 
 > **Pro tip**: try to avoid enabling this setting where possible. If you
@@ -177,7 +177,7 @@ It will show SHA256, MD5, BLAKE2-256 values of files to be uploaded.
 
 ```yml
   with:
-    print_hash: true
+    print-hash: true
 ```
 
 ### Specifying a different username

--- a/action.yml
+++ b/action.yml
@@ -9,29 +9,74 @@ inputs:
   password:
     description: Password for your PyPI user or an access token
     required: true
-  repository_url:
+  repository-url:  # Canonical alias for `repository_url`
     description: The repository URL to use
     required: false
-  packages_dir:
+  repository_url:  # DEPRECATED ALIAS; TODO: Remove in v3+
+    description: >-
+      [DEPRECATED]
+      The repository URL to use
+    deprecationMessage: >-
+      The inputs have been normalized to use kebab-case.
+      Use `repository-url` instead.
+    required: false
+  packages-dir:  # Canonical alias for `packages_dir`
     description: The target directory for distribution
     required: false
     default: dist
-  verify_metadata:
+  packages_dir:  # DEPRECATED ALIAS; TODO: Remove in v3+
+    description: >-
+      [DEPRECATED]
+      The target directory for distribution
+    deprecationMessage: >-
+      The inputs have been normalized to use kebab-case.
+      Use `packages-dir` instead.
+    required: false
+    default: dist
+  verify-metadata:  # Canonical alias for `verify_metadata`
     description: Check metadata before uploading
     required: false
     default: 'true'
-  skip_existing:
+  verify_metadata:  # DEPRECATED ALIAS; TODO: Remove in v3+
+    description: >-
+      [DEPRECATED]
+      Check metadata before uploading
+    deprecationMessage: >-
+      The inputs have been normalized to use kebab-case.
+      Use `verify-metadata` instead.
+    required: false
+    default: 'true'
+  skip-existing:  # Canonical alias for `skip_existing`
     description: >-
       Do not fail if a Python package distribution
       exists in the target package index
+    required: false
+    default: 'false'
+  skip_existing:  # DEPRECATED ALIAS; TODO: Remove in v3+
+    description: >-
+      [DEPRECATED]
+      Do not fail if a Python package distribution
+      exists in the target package index
+    deprecationMessage: >-
+      The inputs have been normalized to use kebab-case.
+      Use `skip-existing` instead.
     required: false
     default: 'false'
   verbose:
     description: Show verbose output.
     required: false
     default: 'false'
-  print_hash:
+  print-hash:  # Canonical alias for `print_hash`
     description: Show hash values of files to be uploaded
+    required: false
+    default: 'false'
+  print_hash:  # DEPRECATED ALIAS; TODO: Remove in v3+
+    description: >-
+      [DEPRECATED]
+      Show hash values of files to be uploaded
+    deprecationMessage: >-
+      The inputs have been normalized to use kebab-case.
+      Use `print-hash` instead.
     required: false
     default: 'false'
 branding:
@@ -43,9 +88,9 @@ runs:
   args:
   - ${{ inputs.user }}
   - ${{ inputs.password }}
-  - ${{ inputs.repository_url }}
-  - ${{ inputs.packages_dir }}
-  - ${{ inputs.verify_metadata }}
-  - ${{ inputs.skip_existing }}
+  - ${{ inputs.repository-url }}
+  - ${{ inputs.packages-dir }}
+  - ${{ inputs.verify-metadata }}
+  - ${{ inputs.skip-existing }}
   - ${{ inputs.verbose }}
-  - ${{ inputs.print_hash }}
+  - ${{ inputs.print-hash }}

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -18,6 +18,26 @@ export PATH="$(python -m site --user-base)/bin:${PATH}"
 export PYTHONPATH="$(python -m site --user-site):${PYTHONPATH}"
 
 
+function get-normalized-input() {
+  local var_name=${1}
+  python -c \
+    '
+from os import getenv
+from sys import argv
+envvar_name = f"INPUT_{argv[1].upper()}"
+print(getenv(envvar_name, getenv(envvar_name.replace("-", "_"), "")), end="")
+    ' \
+    "${var_name}"
+}
+
+
+INPUT_REPOSITORY_URL="$(get-normalized-input 'repository-url')"
+INPUT_PACKAGES_DIR="$(get-normalized-input 'packages-dir')"
+INPUT_VERIFY_METADATA="$(get-normalized-input 'verify-metadata')"
+INPUT_SKIP_EXISTING="$(get-normalized-input 'skip-existing')"
+INPUT_PRINT_HASH="$(get-normalized-input 'print-hash')"
+
+
 if [[
     "$INPUT_USER" == "__token__" &&
     ! "$INPUT_PASSWORD" =~ ^pypi-


### PR DESCRIPTION
Up until now, the action input names followed the snake_case naming pattern that is well familiar to the pythonistas. But in GitHub actions, the de-facto standard is using kebab-case, which is what this patch achieves.
This style helps make the keys in YAML better standardized and distinguishable from other identifiers.
The old snake_case names remain functional for the time being and will not be removed until at least v3 release of this action.