### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,18 +1,20 @@
+---
 # https://beta.ruff.rs/docs
 name: ruff
 on:
-  push:
-    branches:
-      - master
-      - unstable/v1
-  pull_request:
-    branches:
-      - master
-      - unstable/v1
+    push:
+        branches:
+            - master
+            - unstable/v1
+    pull_request:
+        branches:
+            - master
+            - unstable/v1
 jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - run: pip install --user ruff
-    - run: ruff --format=github --target-version=py37 .
+    ruff:
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        steps:
+          - uses: actions/checkout@v3
+          - run: pip install --user ruff
+          - run: ruff --format=github --target-version=py37 .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,18 @@
+# https://beta.ruff.rs/docs
+name: ruff
+on:
+  push:
+    branches:
+      - master
+      - unstable/v1
+  pull_request:
+    branches:
+      - master
+      - unstable/v1
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github --target-version=py37 .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -2,19 +2,19 @@
 # https://beta.ruff.rs/docs
 name: ruff
 on:
-    push:
-        branches:
-            - master
-            - unstable/v1
-    pull_request:
-        branches:
-            - master
-            - unstable/v1
+  push:
+    branches:
+    - master
+    - unstable/v1
+  pull_request:
+    branches:
+    - master
+    - unstable/v1
 jobs:
-    ruff:
-        runs-on: ubuntu-latest
-        timeout-minutes: 2
-        steps:
-          - uses: actions/checkout@v3
-          - run: pip install --user ruff
-          - run: ruff --format=github --target-version=py37 .
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github --target-version=py37 .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,7 +1,7 @@
 ---
 # https://beta.ruff.rs/docs
 name: ruff
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
     - master


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)