### PR TITLE
oidc-exchange: avoid splitting the error message

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -55,10 +55,7 @@ def die(msg: str) -> NoReturn:
     with _GITHUB_STEP_SUMMARY.open("a", encoding="utf-8") as io:
         print(msg, file=io)
 
-    # NOTE: `msg` is Markdown formatted, so we emit only the header line to
-    # avoid clogging the console log with a full Markdown formatted document.
-    header = msg.splitlines()[0]
-    print(f"::error::OIDC exchange failure: {header}", file=sys.stderr)
+    print(f"::error::OIDC exchange failure: {msg}", file=sys.stderr)
     sys.exit(1)
 
 


### PR DESCRIPTION
From user feedback: users found the single "header" error line on the console confusing, and didn't immediately realize that the full error was provided in the job summary.

This just changes the console logging behavior to dump the whole error message, rather than just the header line. This shouldn't be a significant readability issue, since the message is Markdown-formatted.