### PR TITLE
OIDC CI log: remove double spaces

### DIFF
--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -44,17 +44,17 @@ if [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] ; then
     # No password supplied by the user implies that we're in the OIDC flow;
     # retrieve the OIDC credential and exchange it for a PyPI API token.
     echo \
-        '::notice::Attempting to perform OIDC credential exchange ' \
-        'to retrieve a temporary short-lived API token for authentication ' \
+        '::notice::Attempting to perform OIDC credential exchange' \
+        'to retrieve a temporary short-lived API token for authentication' \
         "against ${INPUT_REPOSITORY_URL}"
     INPUT_PASSWORD="$(python /app/oidc-exchange.py)"
 elif [[ "${INPUT_USER}" == '__token__' ]]; then
     echo \
-        '::notice::Using a user-provided API token for authentication ' \
+        '::notice::Using a user-provided API token for authentication' \
         "against ${INPUT_REPOSITORY_URL}"
 else
     echo \
-        '::notice::Using a username + password pair for authentication ' \
+        '::notice::Using a username + password pair for authentication' \
         "against ${INPUT_REPOSITORY_URL}}"
 fi
 


### PR DESCRIPTION

There are double spaces in the log entry:

`Notice: Attempting to perform OIDC credential exchange  to retrieve a temporary short-lived API token for authentication  against https://test.pypi.org/legacy/`

https://github.com/hugovk/pypistats/actions/runs/4556420575/jobs/8036751224#step:8:20

Looks like the newline or something gets counted as a space, so let's remove the extra spaces.