### PR TITLE
README, oidc-exchange: remove beta references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ settings page of your project on GitHub. See [Creating & using secrets].
 
 ### Trusted publishing
 
+> **NOTE**: Trusted publishing is sometimes referred to by its
+> underlying technology -- OpenID Connect, or OIDC for short.
+> If you see references to "OIDC publishing" in the context of PyPI,
+> this is what they're referring to.
+
 This action supports PyPI's [trusted publishing]
 implementation, which allows authentication to PyPI without a manually
 configured API token or username/password combination. To perform

--- a/README.md
+++ b/README.md
@@ -67,15 +67,6 @@ settings page of your project on GitHub. See [Creating & using secrets].
 
 ### Trusted publishing
 
-> **IMPORTANT**: This functionality is in beta, and will not work for you
-> unless you're a member of the PyPI trusted publishing beta testers' group.
-> For more information, see [warehouse#12965].
-
-> **NOTE**: Trusted publishing is sometimes referred to by its
-> underlying technology -- OpenID Connect, or OIDC for short.
-> If you see references to "OIDC publishing" in the context of PyPI,
-> this is what they're referring to.
-
 This action supports PyPI's [trusted publishing]
 implementation, which allows authentication to PyPI without a manually
 configured API token or username/password combination. To perform

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -96,7 +96,7 @@ def assert_successful_audience_call(resp: requests.Response, domain: str):
     match resp.status_code:
         case HTTPStatus.FORBIDDEN:
             # This index supports OIDC, but forbids the client from using
-            # it (either because it's disabled, limited to a beta group, etc.)
+            # it (either because it's disabled, ratelimited, etc.)
             die(
                 f"audience retrieval failed: repository at {domain} has trusted publishing disabled",
             )


### PR DESCRIPTION
Now that trusted publishing is in GA, these can be removed!

We've also fully removed public references to OIDC in the PyPI docs, so the caveat for that can also be removed.