### PR TITLE
Unrequire the `password` input in action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: __token__
   password:
     description: Password for your PyPI user or an access token
-    required: true
+    required: false
   repository-url:  # Canonical alias for `repository_url`
     description: The repository URL to use
     required: false


### PR DESCRIPTION
In https://github.com/pypa/gh-action-pypi-publish/pull/123, with Trusted Publishing being implemented, the missing or empty password started being used as a feature flag implying OIDC flow.

Ref: https://github.com/pypa/gh-action-pypi-publish/commit/2b46bad8