### PR TITLE
Bump runtime dependencies

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -7,13 +7,3 @@ id ~= 1.0
 # NOTE: it explicitly here because `oidc-exchange.py` uses it.
 # Ref: https://github.com/di/id
 requests
-
-# NOTE: `pkginfo` is a transitive dependency for us that is coming from Twine.
-# NOTE: It is declared here only to avoid installing a broken combination of
-# NOTE: the distribution packages. This should be removed once a fixed version
-# NOTE: of Twine is out.
-# Refs:
-# * https://github.com/pypa/gh-action-pypi-publish/issues/107
-# * https://github.com/pypa/twine/issues/940
-# * https://github.com/pypa/twine/pull/941
-pkginfo != 1.9.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,77 +4,83 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/runtime.txt --resolver=backtracking --strip-extras requirements/runtime.in
 #
-bleach==5.0.1
+annotated-types==0.5.0
+    # via pydantic
+bleach==6.0.0
     # via readme-renderer
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.2.0
     # via requests
-commonmark==0.9.1
-    # via rich
-cryptography==41.0.0
+cryptography==41.0.2
     # via secretstorage
-docutils==0.19
+docutils==0.20.1
     # via readme-renderer
 id==1.0.0
-    # via -r runtime.in
+    # via -r requirements/runtime.in
 idna==3.4
     # via requests
-importlib-metadata==5.1.0
+importlib-metadata==6.8.0
     # via
     #   keyring
     #   twine
-jaraco-classes==3.2.3
+jaraco-classes==3.3.0
     # via keyring
 jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-keyring==23.11.0
+keyring==24.2.0
     # via twine
-more-itertools==9.0.0
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==9.1.0
     # via jaraco-classes
-pkginfo==1.9.2
-    # via
-    #   -r runtime.in
-    #   twine
+pkginfo==1.9.6
+    # via twine
 pycparser==2.21
     # via cffi
-pydantic==1.10.6
+pydantic==2.0.2
     # via id
-pygments==2.13.0
+pydantic-core==2.1.2
+    # via pydantic
+pygments==2.15.1
     # via
     #   readme-renderer
     #   rich
-readme-renderer==37.3
+readme-renderer==40.0
     # via twine
 requests==2.31.0
     # via
-    #   -r runtime.in
+    #   -r requirements/runtime.in
     #   id
     #   requests-toolbelt
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.4.2
     # via twine
 secretstorage==3.3.3
     # via keyring
 six==1.16.0
     # via bleach
-twine==4.0.1
-    # via -r runtime.in
-typing-extensions==4.5.0
-    # via pydantic
-urllib3==1.26.13
+twine==4.0.2
+    # via -r requirements/runtime.in
+typing-extensions==4.7.1
+    # via
+    #   pydantic
+    #   pydantic-core
+urllib3==2.0.3
     # via
     #   requests
     #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.11.0
+zipp==3.16.0
     # via importlib-metadata


### PR DESCRIPTION
dependabot is only configured to update security dependencies, but various updates are interesting here:

 * twine 4.0.2 which has fixed the pkginfo bug back in December 2022
 * urllib3 2.0.3 and requests-toolbelt 1.0.0 (disclaimer: I maintain urllib3 and released requests-toolbelt 1.0.0, the good news being the are fully compatible with twine 4.0.2)
 * pydantic 2.0 (not that you should really care, but their 2.0 numbers are still low and I'd like to encourage them: https://pepy.tech/project/pydantic?versions=2.*&versions=1.*). di/id does not pin pydantic and the [tests are running with pydantic 2.0](https://github.com/di/id/actions/runs/5456430609/jobs/9929224771) which indicates support.