### PR TITLE
oidc-exchange: render claims if exchange fails

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -207,8 +207,8 @@ if not mint_token_resp.ok:
 
     die(
         _SERVER_REFUSED_TOKEN_EXCHANGE_MESSAGE.format(
-            reasons=reasons, rendered_claims=rendered_claims
-        )
+            reasons=reasons, rendered_claims=rendered_claims,
+        ),
     )
 
 pypi_token = mint_token_payload.get("token")

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -146,7 +146,7 @@ def render_claims(token: str) -> str:
     _, payload, _ = token.split(".", 2)
     claims = json.loads(base64.urlsafe_b64decode(payload))
 
-    def _get(name: str) -> str:
+    def _get(name: str) -> str:  # noqa: WPS430
         return claims.get(name, "MISSING")
 
     return _RENDERED_CLAIMS.format(

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -142,8 +142,8 @@ def assert_successful_audience_call(resp: requests.Response, domain: str):
             )
 
 
-def render_claims(oidc_token: str) -> str:
-    _, payload, _ = oidc_token.split(".", 2)
+def render_claims(token: str) -> str:
+    _, payload, _ = token.split(".", 2)
     claims = json.loads(base64.urlsafe_b64decode(payload))
 
     def _get(name: str) -> str:


### PR DESCRIPTION
This will provide additional visibility into errors like we're seeing in #173.