### PR TITLE
oidc-exchange: fix padding

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -144,6 +144,9 @@ def assert_successful_audience_call(resp: requests.Response, domain: str):
 
 def render_claims(token: str) -> str:
     _, payload, _ = token.split(".", 2)
+
+    # urlsafe_b64decode needs padding; JWT payloads don't contain any.
+    payload += "=" * (4 - (len(payload) % 4))
     claims = json.loads(base64.urlsafe_b64decode(payload))
 
     def _get(name: str) -> str:  # noqa: WPS430
@@ -207,7 +210,8 @@ if not mint_token_resp.ok:
 
     die(
         _SERVER_REFUSED_TOKEN_EXCHANGE_MESSAGE.format(
-            reasons=reasons, rendered_claims=rendered_claims,
+            reasons=reasons,
+            rendered_claims=rendered_claims,
         ),
     )
 


### PR DESCRIPTION
JWT payloads aren't padded; this recomputes the padding.

Fixes the crash in https://github.com/pypa/gh-action-pypi-publish/issues/173#issuecomment-1673825631.