### PR TITLE
oidc-exchange: specialize error on PRs from forks

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -57,7 +57,8 @@ pull request on a fork. GitHub doesn't give these workflows OIDC permissions,
 even if `id-token: write` is explicitly configured.
 
 To fix this, change your publishing workflow to use an event that
-forks of your repository cannot trigger (such as tag or release creation).
+forks of your repository cannot trigger (such as tag or release
+creation, or a manually triggered workflow dispatch).
 """
 
 # Rendered if the package index refuses the given OIDC token.

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -182,7 +182,7 @@ def event_is_third_party_pr() -> bool:
 
     if event_path := os.getenv("GITHUB_EVENT_PATH"):
         try:
-            event = json.loads(Path(event_path).read_text())
+            event = json.loads(Path(event_path).read_bytes())
         except json.JSONDecodeError:
             debug("unexpected: GITHUB_EVENT_PATH does not contain valid JSON")
             return False

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -217,8 +217,8 @@ except id.IdentityError as identity_error:
     if event_is_third_party_pr():
         die(
             _TOKEN_RETRIEVAL_FAILED_FORK_PR_MESSAGE.format(
-                identity_error=identity_error
-            )
+                identity_error=identity_error,
+            ),
         )
     else:
         die(_TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error))

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -181,21 +181,22 @@ def event_is_third_party_pr() -> bool:
     if os.getenv("GITHUB_EVENT_NAME") != "pull_request":
         return False
 
-    if event_path := os.getenv("GITHUB_EVENT_PATH"):
-        try:
-            event = json.loads(Path(event_path).read_bytes())
-        except json.JSONDecodeError:
-            debug("unexpected: GITHUB_EVENT_PATH does not contain valid JSON")
-            return False
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        # No GITHUB_EVENT_PATH indicates a weird GitHub or runner bug.
+        debug("unexpected: no GITHUB_EVENT_PATH to check")
+        return False
 
-        try:
-            return event["pull_request"]["head"]["repo"]["fork"]
-        except KeyError:
-            return False
+    try:
+        event = json.loads(Path(event_path).read_bytes())
+    except json.JSONDecodeError:
+        debug("unexpected: GITHUB_EVENT_PATH does not contain valid JSON")
+        return False
 
-    # No GITHUB_EVENT_PATH indicates a weird GitHub or runner bug.
-    debug("unexpected: no GITHUB_EVENT_PATH to check")
-    return False
+    try:
+        return event["pull_request"]["head"]["repo"]["fork"]
+    except KeyError:
+        return False
 
 
 repository_url = get_normalized_input("repository-url")

--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -215,14 +215,12 @@ debug(f"selected trusted publishing exchange endpoint: {token_exchange_url}")
 try:
     oidc_token = id.detect_credential(audience=oidc_audience)
 except id.IdentityError as identity_error:
-    if event_is_third_party_pr():
-        die(
-            _TOKEN_RETRIEVAL_FAILED_FORK_PR_MESSAGE.format(
-                identity_error=identity_error,
-            ),
-        )
-    else:
-        die(_TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error))
+    cause_msg_tmpl = (
+        _TOKEN_RETRIEVAL_FAILED_FORK_PR_MESSAGE if event_is_third_party_pr()
+        else _TOKEN_RETRIEVAL_FAILED_MESSAGE
+    )
+    for_cause_msg = cause_msg_tmpl.format(identity_error=identity_error)
+    die(for_cause_msg)
 
 # Now we can do the actual token exchange.
 mint_token_resp = requests.post(


### PR DESCRIPTION
This specializes the token retrieval error handling a bit, providing an alternative error message when the error cause is something that we know can't possibly work due to GitHub's own restrictions on PRs from forks.

Closes #202.

See https://github.com/python-pillow/Pillow/pull/7616.