### PR TITLE
oidc-exchange: update OIDC minting endpoint

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -164,7 +164,7 @@ def render_claims(token: str) -> str:
 
 repository_url = get_normalized_input("repository-url")
 repository_domain = urlparse(repository_url).netloc
-token_exchange_url = f"https://{repository_domain}/_/oidc/github/mint-token"
+token_exchange_url = f"https://{repository_domain}/_/oidc/mint-token"
 
 # Indices are expected to support `https://{domain}/_/oidc/audience`,
 # which tells OIDC exchange clients which audience to use.


### PR DESCRIPTION
Per https://github.com/pypi/warehouse/pull/15148: the old endpoint is now an alias for this one, with no other behavioral changes. There are no current plans to remove the old alias, but I figure there's no harm in getting ahead of the trendline here 🙂 