### PR TITLE
Fix a deprecation msg typo in the ancient branch: "migrading"->"migrating"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -63,7 +63,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -85,7 +85,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -108,7 +108,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -133,7 +133,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -156,7 +156,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 
@@ -179,7 +179,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
       general recommendation is to pin to exact tags or commit SHAs.
 
 
-      Please also consider migrading your setup to use secretless publishing:
+      Please also consider migrating your setup to use secretless publishing:
       https://github.com/marketplace/actions/pypi-publish#trusted-publishing
 
 


### PR DESCRIPTION
migrading -> migrating