### PR TITLE
twine-upload: fix tense on password nudge

### DIFF
--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -40,9 +40,9 @@ INPUT_VERIFY_METADATA="$(get-normalized-input 'verify-metadata')"
 INPUT_SKIP_EXISTING="$(get-normalized-input 'skip-existing')"
 INPUT_PRINT_HASH="$(get-normalized-input 'print-hash')"
 
-PASSWORD_DEPRECATION_NUDGE="::error title=Password-based uploads deprecated::\
-Starting in 2024, PyPI will require all users to enable Two-Factor \
-Authentication. This will consequently require all users to switch \
+PASSWORD_DEPRECATION_NUDGE="::error title=Password-based uploads disabled::\
+As of 2024, PyPI requires all users to enable Two-Factor \
+Authentication. This consequentlys require all users to switch \
 to either Trusted Publishers (preferred) or API tokens for package \
 uploads. Read more: \
 https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/"
@@ -74,6 +74,7 @@ else
     if [[ "${INPUT_REPOSITORY_URL}" =~ pypi\.org ]]; then
         echo "${PASSWORD_DEPRECATION_NUDGE}"
         echo "${TRUSTED_PUBLISHING_NUDGE}"
+        exit 1
     fi
 fi
 

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -42,7 +42,7 @@ INPUT_PRINT_HASH="$(get-normalized-input 'print-hash')"
 
 PASSWORD_DEPRECATION_NUDGE="::error title=Password-based uploads disabled::\
 As of 2024, PyPI requires all users to enable Two-Factor \
-Authentication. This consequentlys require all users to switch \
+Authentication. This consequently requires all users to switch \
 to either Trusted Publishers (preferred) or API tokens for package \
 uploads. Read more: \
 https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/"


### PR DESCRIPTION
This also makes the password case a hard error on `pypi.org`, since we know it's going to fail. But I'm happy to revert that if you'd prefer to display the error and let `twine upload` fail instead 🙂 

Fixes #233 