### PR TITLE
Expose PEP 740 attestations functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY LICENSE.md .
 COPY twine-upload.sh .
 COPY print-hash.py .
 COPY oidc-exchange.py .
+COPY attestations.py .
 
 RUN chmod +x twine-upload.sh
 ENTRYPOINT ["/app/twine-upload.sh"]

--- a/README.md
+++ b/README.md
@@ -246,6 +246,25 @@ for example. See [Creating & using secrets]. While still secure,
 [trusted publishing] is now encouraged over API tokens as a best practice
 on supported platforms (like GitHub).
 
+### Generating and uploading attestations (EXPERIMENTAL)
+
+> [!NOTE]
+> Support for generating and uploading [PEP 740 attestations] is currently
+> experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
+
+You can generate signed [PEP 740 attestations] for all the distribution files and
+upload them all together by enabling the `attestations` setting:
+
+```yml
+   with:
+     attestations: true
+```
+
+This will use `sigstore` to create attestation objects for each distribution package,
+signing them with the identity provided by the GitHub's OIDC token associated with the
+current workflow. This means both the trusted publishing authentication and the
+attestations are tied to the same identity.
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project
@@ -287,3 +306,5 @@ https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
 [configured on PyPI]: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
 [how to specify username and password]: #specifying-a-different-username
+
+[PEP 740 attestations]: https://peps.python.org/pep-0740/

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ filter to the job:
 ### Generating and uploading attestations
 
 > [!IMPORTANT]
-> Support for generating and uploading [PEP 740 attestations] is currently
+> Support for generating and uploading [digital attestations] is currently
 > experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
 
-You can generate signed [PEP 740 attestations] for all the distribution files and
+You can generate signed [digital attestations] for all the distribution files and
 upload them all together by enabling the `attestations` setting:
 
 ```yml
@@ -307,5 +307,5 @@ https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
 
 [how to specify username and password]: #specifying-a-different-username
 
-[PEP 740 attestations]: https://peps.python.org/pep-0740/
+[digital attestations]: https://peps.python.org/pep-0740/
 [Sigstore]: https://www.sigstore.dev/

--- a/README.md
+++ b/README.md
@@ -260,10 +260,11 @@ upload them all together by enabling the `attestations` setting:
      attestations: true
 ```
 
-This will use `sigstore` to create attestation objects for each distribution package,
-signing them with the identity provided by the GitHub's OIDC token associated with the
-current workflow. This means both the trusted publishing authentication and the
-attestations are tied to the same identity.
+This will use [Sigstore](https://www.sigstore.dev/) to create attestation
+objects for each distribution package, signing them with the identity provided
+by the GitHub's OIDC token associated with the current workflow. This means
+both the trusted publishing authentication and the attestations are tied to the
+same identity.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ filter to the job:
 > Support for generating and uploading [digital attestations] is currently
 > experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
 
+> [!NOTE]
+> Generating and uploading digital attestations currently requires
+> authentication with a [trusted publisher].
+
 You can generate signed [digital attestations] for all the distribution files and
 upload them all together by enabling the `attestations` setting:
 
@@ -309,3 +313,4 @@ https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
 
 [digital attestations]: https://peps.python.org/pep-0740/
 [Sigstore]: https://www.sigstore.dev/
+[trusted publisher]: #trusted-publishing

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ filter to the job:
 > [!IMPORTANT]
 > Support for generating and uploading [digital attestations] is currently
 > experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
+> Support for this feature is not yet stable; the settings and behavior described
+> below may change without prior notice.
 
 > [!NOTE]
 > Generating and uploading digital attestations currently requires

--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ filter to the job:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 ```
 
+### Generating and uploading attestations
+
+> [!IMPORTANT]
+> Support for generating and uploading [PEP 740 attestations] is currently
+> experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
+
+You can generate signed [PEP 740 attestations] for all the distribution files and
+upload them all together by enabling the `attestations` setting:
+
+```yml
+   with:
+     attestations: true
+```
+
+This will use [Sigstore] to create attestation
+objects for each distribution package, signing them with the identity provided
+by the GitHub's OIDC token associated with the current workflow. This means
+both the trusted publishing authentication and the attestations are tied to the
+same identity.
 
 ## Non-goals
 
@@ -246,26 +265,6 @@ for example. See [Creating & using secrets]. While still secure,
 [trusted publishing] is now encouraged over API tokens as a best practice
 on supported platforms (like GitHub).
 
-### Generating and uploading attestations (EXPERIMENTAL)
-
-> [!NOTE]
-> Support for generating and uploading [PEP 740 attestations] is currently
-> experimental and limited only to Trusted Publishing flows using PyPI or TestPyPI.
-
-You can generate signed [PEP 740 attestations] for all the distribution files and
-upload them all together by enabling the `attestations` setting:
-
-```yml
-   with:
-     attestations: true
-```
-
-This will use [Sigstore](https://www.sigstore.dev/) to create attestation
-objects for each distribution package, signing them with the identity provided
-by the GitHub's OIDC token associated with the current workflow. This means
-both the trusted publishing authentication and the attestations are tied to the
-same identity.
-
 ## License
 
 The Dockerfile and associated scripts and documentation in this project
@@ -309,3 +308,4 @@ https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
 [how to specify username and password]: #specifying-a-different-username
 
 [PEP 740 attestations]: https://peps.python.org/pep-0740/
+[Sigstore]: https://www.sigstore.dev/

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,13 @@ inputs:
       Use `print-hash` instead.
     required: false
     default: 'false'
+  attestations:
+    description: >-
+      [EXPERIMENTAL]
+      Enable experimental support for PEP 740 attestations.
+      Only works with PyPI and TestPyPI via Trusted Publishing.
+    required: false
+    default: 'false'
 branding:
   color: yellow
   icon: upload-cloud
@@ -95,3 +102,4 @@ runs:
   - ${{ inputs.skip-existing }}
   - ${{ inputs.verbose }}
   - ${{ inputs.print-hash }}
+  - ${{ inputs.attestations }}

--- a/attestations.py
+++ b/attestations.py
@@ -96,5 +96,6 @@ for dist in dists:
 
 
 with SigningContext.production().signer(identity, cache=True) as s:
+    debug(f'attesting to dists: {dists}')
     for dist in dists:
         attest_dist(dist, s)

--- a/attestations.py
+++ b/attestations.py
@@ -1,0 +1,102 @@
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+from pypi_attestation_models import AttestationPayload
+from sigstore.oidc import IdentityError, IdentityToken, detect_credential
+from sigstore.sign import Signer, SigningContext
+
+# Be very verbose.
+sigstore_logger = logging.getLogger("sigstore")
+sigstore_logger.setLevel(logging.DEBUG)
+sigstore_logger.addHandler(logging.StreamHandler())
+
+_GITHUB_STEP_SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY"))
+
+# The top-level error message that gets rendered.
+# This message wraps one of the other templates/messages defined below.
+_ERROR_SUMMARY_MESSAGE = """
+Attestation generation failure:
+
+{message}
+
+You're seeing this because the action attempted to generated PEP 740
+attestations for its inputs, but failed to do so.
+"""
+
+# Rendered if OIDC identity token retrieval fails for any reason.
+_TOKEN_RETRIEVAL_FAILED_MESSAGE = """
+OpenID Connect token retrieval failed: {identity_error}
+
+This generally indicates a workflow configuration error, such as insufficient
+permissions. Make sure that your workflow has `id-token: write` configured
+at the job level, e.g.:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+Learn more at https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings.
+"""
+
+
+def die(msg: str) -> NoReturn:
+    with _GITHUB_STEP_SUMMARY.open("a", encoding="utf-8") as io:
+        print(_ERROR_SUMMARY_MESSAGE.format(message=msg), file=io)
+
+    # HACK: GitHub Actions' annotations don't work across multiple lines naively;
+    # translating `\n` into `%0A` (i.e., HTML percent-encoding) is known to work.
+    # See: https://github.com/actions/toolkit/issues/193
+    msg = msg.replace("\n", "%0A")
+    print(f"::error::Attestation generation failure: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def debug(msg: str):
+    print(f"::debug::{msg}", file=sys.stderr)
+
+
+# pylint: disable=redefined-outer-name
+def attest_dist(dist: Path, signer: Signer) -> None:
+    # We are the publishing step, so there should be no pre-existing publish
+    # attestation. The presence of one indicates user confusion.
+    attestation_path = Path(f"{dist}.publish.attestation")
+    if attestation_path.is_file():
+        die(f"{dist} already has a publish attestation: {attestation_path}")
+
+    payload = AttestationPayload.from_dist(dist)
+    attestation = payload.sign(signer)
+
+    attestation_path.write_text(attestation.model_dump_json(), encoding="utf-8")
+    debug(f"saved publish attestation: {dist=} {attestation_path=}")
+
+
+packages_dir = Path(sys.argv[1])
+
+try:
+    # NOTE: audience is always sigstore.
+    oidc_token = detect_credential()
+    identity = IdentityToken(oidc_token)
+except IdentityError as identity_error:
+    # NOTE: We only perform attestations in trusted publishing flows, so we
+    # don't need to re-check for the "PR from fork" error mode, only
+    # generic token retrieval errors.
+    cause = _TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error)
+    die(cause)
+
+# Collect all sdists and wheels.
+dists = [sdist.absolute() for sdist in packages_dir.glob("*.tar.gz")]
+dists.extend(whl.absolute() for whl in packages_dir.glob("*.whl"))
+
+with SigningContext.production().signer(identity, cache=True) as signer:
+    for dist in dists:
+        # This should never really happen, but some versions of GitHub's
+        # download-artifact will create a subdirectory with the same name
+        # as the artifact being downloaded, e.g. `dist/foo.whl/foo.whl`.
+        if not dist.is_file():
+            die(f"Path looks like a distribution but is not a file: {dist}")
+
+        attest_dist(dist, signer)

--- a/attestations.py
+++ b/attestations.py
@@ -89,12 +89,13 @@ except IdentityError as identity_error:
 dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
 dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
 
+# Make sure everything that looks like a dist actually is one.
+# We do this up-front to prevent partial signing.
+for dist in dists:
+    if not dist.is_file():
+        die(f'Path looks like a distribution but is not a file: {dist}')
+
+
 with SigningContext.production().signer(identity, cache=True) as signer:
     for dist in dists:
-        # This should never really happen, but some versions of GitHub's
-        # download-artifact will create a subdirectory with the same name
-        # as the artifact being downloaded, e.g. `dist/foo.whl/foo.whl`.
-        if not dist.is_file():
-            die(f'Path looks like a distribution but is not a file: {dist}')
-
         attest_dist(dist, signer)

--- a/attestations.py
+++ b/attestations.py
@@ -83,8 +83,7 @@ def main() -> None:
         # don't need to re-check for the "PR from fork" error mode, only
         # generic token retrieval errors. We also render a simpler error,
         # since permissions can't be to blame at this stage.
-        cause = _TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error)
-        die(cause)
+        die(_TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error))
 
     # Collect all sdists and wheels.
     dist_paths = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
@@ -100,6 +99,7 @@ def main() -> None:
         debug(f'attesting to dists: {dist_paths}')
         for dist_path in dist_paths:
             attest_dist(dist_path, s)
+
 
 if __name__ == '__main__':
     main()

--- a/attestations.py
+++ b/attestations.py
@@ -51,6 +51,23 @@ def debug(msg: str):
     print(f'::debug::{msg}', file=sys.stderr)
 
 
+def collect_dists(packages_dir: Path) -> list[Path]:
+    # Collect all sdists and wheels.
+    dist_paths = [sdist.resolve() for sdist in packages_dir.glob('*.tar.gz')]
+    dist_paths.extend(whl.resolve() for whl in packages_dir.glob('*.whl'))
+
+    # Make sure everything that looks like a dist actually is one.
+    # We do this up-front to prevent partial signing.
+    if (invalid_dists := [path for path in dist_paths if path.is_file()]):
+        invalid_dist_list = ', '.join(map(str, invalid_dists))
+        die(
+            'The following paths look like distributions but '
+            f'are not actually files: {invalid_dist_list}',
+        )
+
+    return dist_paths
+
+
 def attest_dist(dist_path: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
@@ -85,18 +102,7 @@ def main() -> None:
         # since permissions can't be to blame at this stage.
         die(_TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error))
 
-    # Collect all sdists and wheels.
-    dist_paths = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
-    dist_paths.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
-
-    # Make sure everything that looks like a dist actually is one.
-    # We do this up-front to prevent partial signing.
-    if (invalid_dists := [_path for _path in dist_paths if _path.is_file()]):
-        invalid_dist_list = ', '.join(map(str, invalid_dists))
-        die(
-            'The following paths look like distributions but '
-            f'are not actually files: {invalid_dist_list}',
-        )
+    dist_paths = collect_dists(packages_dir)
 
     with SigningContext.production().signer(identity, cache=True) as s:
         debug(f'attesting to dists: {dist_paths}')

--- a/attestations.py
+++ b/attestations.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
-from pypi_attestations import Attestation
+from pypi_attestations import Attestation, Distribution
 from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 
@@ -58,7 +58,8 @@ def attest_dist(dist_path: Path, signer: Signer) -> None:
     if attestation_path.is_file():
         die(f'{dist_path} already has a publish attestation: {attestation_path}')
 
-    attestation = Attestation.sign(signer, dist_path)
+    dist = Distribution.from_file(dist_path)
+    attestation = Attestation.sign(signer, dist)
 
     attestation_path.write_text(attestation.model_dump_json(), encoding='utf-8')
     debug(f'saved publish attestation: {dist_path=} {attestation_path=}')

--- a/attestations.py
+++ b/attestations.py
@@ -51,18 +51,17 @@ def debug(msg: str):
     print(f'::debug::{msg}', file=sys.stderr)
 
 
-# pylint: disable=redefined-outer-name
-def attest_dist(dist: Path, signer: Signer) -> None:
+def attest_dist(dist_path: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
-    attestation_path = Path(f'{dist}.publish.attestation')
+    attestation_path = Path(f'{dist_path}.publish.attestation')
     if attestation_path.is_file():
-        die(f'{dist} already has a publish attestation: {attestation_path}')
+        die(f'{dist_path} already has a publish attestation: {attestation_path}')
 
-    attestation = Attestation.sign(signer, dist)
+    attestation = Attestation.sign(signer, dist_path)
 
     attestation_path.write_text(attestation.model_dump_json(), encoding='utf-8')
-    debug(f'saved publish attestation: {dist=} {attestation_path=}')
+    debug(f'saved publish attestation: {dist_path=} {attestation_path=}')
 
 
 def get_identity_token() -> IdentityToken:
@@ -96,6 +95,6 @@ for dist in dists:
         die(f'Path looks like a distribution but is not a file: {dist}')
 
 
-with SigningContext.production().signer(identity, cache=True) as signer:
+with SigningContext.production().signer(identity, cache=True) as s:
     for dist in dists:
-        attest_dist(dist, signer)
+        attest_dist(dist, s)

--- a/attestations.py
+++ b/attestations.py
@@ -4,16 +4,16 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
-from pypi_attestation_models import AttestationPayload
+from pypi_attestation_models import Attestation
 from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 
 # Be very verbose.
-sigstore_logger = logging.getLogger('sigstore')
+sigstore_logger = logging.getLogger("sigstore")
 sigstore_logger.setLevel(logging.DEBUG)
 sigstore_logger.addHandler(logging.StreamHandler())
 
-_GITHUB_STEP_SUMMARY = Path(os.getenv('GITHUB_STEP_SUMMARY'))
+_GITHUB_STEP_SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY"))
 
 # The top-level error message that gets rendered.
 # This message wraps one of the other templates/messages defined below.
@@ -44,34 +44,33 @@ Learn more at https://docs.github.com/en/actions/deployment/security-hardening-y
 
 
 def die(msg: str) -> NoReturn:
-    with _GITHUB_STEP_SUMMARY.open('a', encoding='utf-8') as io:
+    with _GITHUB_STEP_SUMMARY.open("a", encoding="utf-8") as io:
         print(_ERROR_SUMMARY_MESSAGE.format(message=msg), file=io)
 
     # HACK: GitHub Actions' annotations don't work across multiple lines naively;
     # translating `\n` into `%0A` (i.e., HTML percent-encoding) is known to work.
     # See: https://github.com/actions/toolkit/issues/193
-    msg = msg.replace('\n', '%0A')
-    print(f'::error::Attestation generation failure: {msg}', file=sys.stderr)
+    msg = msg.replace("\n", "%0A")
+    print(f"::error::Attestation generation failure: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
 def debug(msg: str):
-    print(f'::debug::{msg}', file=sys.stderr)
+    print(f"::debug::{msg}", file=sys.stderr)
 
 
 # pylint: disable=redefined-outer-name
 def attest_dist(dist: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
-    attestation_path = Path(f'{dist}.publish.attestation')
+    attestation_path = Path(f"{dist}.publish.attestation")
     if attestation_path.is_file():
-        die(f'{dist} already has a publish attestation: {attestation_path}')
+        die(f"{dist} already has a publish attestation: {attestation_path}")
 
-    payload = AttestationPayload.from_dist(dist)
-    attestation = payload.sign(signer)
+    attestation = Attestation.sign(signer, dist)
 
-    attestation_path.write_text(attestation.model_dump_json(), encoding='utf-8')
-    debug(f'saved publish attestation: {dist=} {attestation_path=}')
+    attestation_path.write_text(attestation.model_dump_json(), encoding="utf-8")
+    debug(f"saved publish attestation: {dist=} {attestation_path=}")
 
 
 def get_identity_token() -> IdentityToken:
@@ -94,8 +93,8 @@ except IdentityError as identity_error:
     die(cause)
 
 # Collect all sdists and wheels.
-dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
-dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
+dists = [sdist.absolute() for sdist in packages_dir.glob("*.tar.gz")]
+dists.extend(whl.absolute() for whl in packages_dir.glob("*.whl"))
 
 with SigningContext.production().signer(identity, cache=True) as signer:
     for dist in dists:
@@ -103,6 +102,6 @@ with SigningContext.production().signer(identity, cache=True) as signer:
         # download-artifact will create a subdirectory with the same name
         # as the artifact being downloaded, e.g. `dist/foo.whl/foo.whl`.
         if not dist.is_file():
-            die(f'Path looks like a distribution but is not a file: {dist}')
+            die(f"Path looks like a distribution but is not a file: {dist}")
 
         attest_dist(dist, signer)

--- a/attestations.py
+++ b/attestations.py
@@ -9,11 +9,11 @@ from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 
 # Be very verbose.
-sigstore_logger = logging.getLogger("sigstore")
+sigstore_logger = logging.getLogger('sigstore')
 sigstore_logger.setLevel(logging.DEBUG)
 sigstore_logger.addHandler(logging.StreamHandler())
 
-_GITHUB_STEP_SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY"))
+_GITHUB_STEP_SUMMARY = Path(os.getenv('GITHUB_STEP_SUMMARY'))
 
 # The top-level error message that gets rendered.
 # This message wraps one of the other templates/messages defined below.
@@ -40,46 +40,52 @@ permissions:
 ```
 
 Learn more at https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings.
-"""
+"""  # noqa: S105; not a password
 
 
 def die(msg: str) -> NoReturn:
-    with _GITHUB_STEP_SUMMARY.open("a", encoding="utf-8") as io:
+    with _GITHUB_STEP_SUMMARY.open('a', encoding='utf-8') as io:
         print(_ERROR_SUMMARY_MESSAGE.format(message=msg), file=io)
 
     # HACK: GitHub Actions' annotations don't work across multiple lines naively;
     # translating `\n` into `%0A` (i.e., HTML percent-encoding) is known to work.
     # See: https://github.com/actions/toolkit/issues/193
-    msg = msg.replace("\n", "%0A")
-    print(f"::error::Attestation generation failure: {msg}", file=sys.stderr)
+    msg = msg.replace('\n', '%0A')
+    print(f'::error::Attestation generation failure: {msg}', file=sys.stderr)
     sys.exit(1)
 
 
 def debug(msg: str):
-    print(f"::debug::{msg}", file=sys.stderr)
+    print(f'::debug::{msg}', file=sys.stderr)
 
 
 # pylint: disable=redefined-outer-name
 def attest_dist(dist: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
-    attestation_path = Path(f"{dist}.publish.attestation")
+    attestation_path = Path(f'{dist}.publish.attestation')
     if attestation_path.is_file():
-        die(f"{dist} already has a publish attestation: {attestation_path}")
+        die(f'{dist} already has a publish attestation: {attestation_path}')
 
     payload = AttestationPayload.from_dist(dist)
     attestation = payload.sign(signer)
 
-    attestation_path.write_text(attestation.model_dump_json(), encoding="utf-8")
-    debug(f"saved publish attestation: {dist=} {attestation_path=}")
+    attestation_path.write_text(attestation.model_dump_json(), encoding='utf-8')
+    debug(f'saved publish attestation: {dist=} {attestation_path=}')
+
+
+def get_identity_token() -> IdentityToken:
+    # Will raise `sigstore.oidc.IdentityError` if it fails to get the token
+    # from the environment or if the token is malformed.
+    # NOTE: audience is always sigstore.
+    oidc_token = detect_credential()
+    return IdentityToken(oidc_token)
 
 
 packages_dir = Path(sys.argv[1])
 
 try:
-    # NOTE: audience is always sigstore.
-    oidc_token = detect_credential()
-    identity = IdentityToken(oidc_token)
+    identity = get_identity_token()
 except IdentityError as identity_error:
     # NOTE: We only perform attestations in trusted publishing flows, so we
     # don't need to re-check for the "PR from fork" error mode, only
@@ -88,8 +94,8 @@ except IdentityError as identity_error:
     die(cause)
 
 # Collect all sdists and wheels.
-dists = [sdist.absolute() for sdist in packages_dir.glob("*.tar.gz")]
-dists.extend(whl.absolute() for whl in packages_dir.glob("*.whl"))
+dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
+dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
 
 with SigningContext.production().signer(identity, cache=True) as signer:
     for dist in dists:
@@ -97,6 +103,6 @@ with SigningContext.production().signer(identity, cache=True) as signer:
         # download-artifact will create a subdirectory with the same name
         # as the artifact being downloaded, e.g. `dist/foo.whl/foo.whl`.
         if not dist.is_file():
-            die(f"Path looks like a distribution but is not a file: {dist}")
+            die(f'Path looks like a distribution but is not a file: {dist}')
 
         attest_dist(dist, signer)

--- a/attestations.py
+++ b/attestations.py
@@ -72,7 +72,7 @@ def attest_dist(dist_path: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
     attestation_path = Path(f'{dist_path}.publish.attestation')
-    if attestation_path.is_file():
+    if attestation_path.exists():
         die(f'{dist_path} already has a publish attestation: {attestation_path}')
 
     dist = Distribution.from_file(dist_path)

--- a/attestations.py
+++ b/attestations.py
@@ -73,30 +73,31 @@ def get_identity_token() -> IdentityToken:
     return IdentityToken(oidc_token)
 
 
-packages_dir = Path(sys.argv[1])
+if __name__ == '__main__':
+    packages_dir = Path(sys.argv[1])
 
-try:
-    identity = get_identity_token()
-except IdentityError as identity_error:
-    # NOTE: We only perform attestations in trusted publishing flows, so we
-    # don't need to re-check for the "PR from fork" error mode, only
-    # generic token retrieval errors. We also render a simpler error,
-    # since permissions can't be to blame at this stage.
-    cause = _TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error)
-    die(cause)
+    try:
+        identity = get_identity_token()
+    except IdentityError as identity_error:
+        # NOTE: We only perform attestations in trusted publishing flows, so we
+        # don't need to re-check for the "PR from fork" error mode, only
+        # generic token retrieval errors. We also render a simpler error,
+        # since permissions can't be to blame at this stage.
+        cause = _TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error)
+        die(cause)
 
-# Collect all sdists and wheels.
-dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
-dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
+    # Collect all sdists and wheels.
+    dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
+    dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
 
-# Make sure everything that looks like a dist actually is one.
-# We do this up-front to prevent partial signing.
-for dist in dists:
-    if not dist.is_file():
-        die(f'Path looks like a distribution but is not a file: {dist}')
-
-
-with SigningContext.production().signer(identity, cache=True) as s:
-    debug(f'attesting to dists: {dists}')
+    # Make sure everything that looks like a dist actually is one.
+    # We do this up-front to prevent partial signing.
     for dist in dists:
-        attest_dist(dist, s)
+        if not dist.is_file():
+            die(f'Path looks like a distribution but is not a file: {dist}')
+
+
+    with SigningContext.production().signer(identity, cache=True) as s:
+        debug(f'attesting to dists: {dists}')
+        for dist in dists:
+            attest_dist(dist, s)

--- a/attestations.py
+++ b/attestations.py
@@ -9,11 +9,11 @@ from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 
 # Be very verbose.
-sigstore_logger = logging.getLogger("sigstore")
+sigstore_logger = logging.getLogger('sigstore')
 sigstore_logger.setLevel(logging.DEBUG)
 sigstore_logger.addHandler(logging.StreamHandler())
 
-_GITHUB_STEP_SUMMARY = Path(os.getenv("GITHUB_STEP_SUMMARY"))
+_GITHUB_STEP_SUMMARY = Path(os.getenv('GITHUB_STEP_SUMMARY'))
 
 # The top-level error message that gets rendered.
 # This message wraps one of the other templates/messages defined below.
@@ -44,33 +44,33 @@ Learn more at https://docs.github.com/en/actions/deployment/security-hardening-y
 
 
 def die(msg: str) -> NoReturn:
-    with _GITHUB_STEP_SUMMARY.open("a", encoding="utf-8") as io:
+    with _GITHUB_STEP_SUMMARY.open('a', encoding='utf-8') as io:
         print(_ERROR_SUMMARY_MESSAGE.format(message=msg), file=io)
 
     # HACK: GitHub Actions' annotations don't work across multiple lines naively;
     # translating `\n` into `%0A` (i.e., HTML percent-encoding) is known to work.
     # See: https://github.com/actions/toolkit/issues/193
-    msg = msg.replace("\n", "%0A")
-    print(f"::error::Attestation generation failure: {msg}", file=sys.stderr)
+    msg = msg.replace('\n', '%0A')
+    print(f'::error::Attestation generation failure: {msg}', file=sys.stderr)
     sys.exit(1)
 
 
 def debug(msg: str):
-    print(f"::debug::{msg}", file=sys.stderr)
+    print(f'::debug::{msg}', file=sys.stderr)
 
 
 # pylint: disable=redefined-outer-name
 def attest_dist(dist: Path, signer: Signer) -> None:
     # We are the publishing step, so there should be no pre-existing publish
     # attestation. The presence of one indicates user confusion.
-    attestation_path = Path(f"{dist}.publish.attestation")
+    attestation_path = Path(f'{dist}.publish.attestation')
     if attestation_path.is_file():
-        die(f"{dist} already has a publish attestation: {attestation_path}")
+        die(f'{dist} already has a publish attestation: {attestation_path}')
 
     attestation = Attestation.sign(signer, dist)
 
-    attestation_path.write_text(attestation.model_dump_json(), encoding="utf-8")
-    debug(f"saved publish attestation: {dist=} {attestation_path=}")
+    attestation_path.write_text(attestation.model_dump_json(), encoding='utf-8')
+    debug(f'saved publish attestation: {dist=} {attestation_path=}')
 
 
 def get_identity_token() -> IdentityToken:
@@ -93,8 +93,8 @@ except IdentityError as identity_error:
     die(cause)
 
 # Collect all sdists and wheels.
-dists = [sdist.absolute() for sdist in packages_dir.glob("*.tar.gz")]
-dists.extend(whl.absolute() for whl in packages_dir.glob("*.whl"))
+dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
+dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
 
 with SigningContext.production().signer(identity, cache=True) as signer:
     for dist in dists:
@@ -102,6 +102,6 @@ with SigningContext.production().signer(identity, cache=True) as signer:
         # download-artifact will create a subdirectory with the same name
         # as the artifact being downloaded, e.g. `dist/foo.whl/foo.whl`.
         if not dist.is_file():
-            die(f"Path looks like a distribution but is not a file: {dist}")
+            die(f'Path looks like a distribution but is not a file: {dist}')
 
         attest_dist(dist, signer)

--- a/attestations.py
+++ b/attestations.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
-from pypi_attestation_models import Attestation
+from pypi_attestations import Attestation
 from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 

--- a/attestations.py
+++ b/attestations.py
@@ -91,9 +91,12 @@ def main() -> None:
 
     # Make sure everything that looks like a dist actually is one.
     # We do this up-front to prevent partial signing.
-    for dist_path in dist_paths:
-        if not dist_path.is_file():
-            die(f'Path looks like a distribution but is not a file: {dist_path}')
+    if (invalid_dists := [_path for _path in dist_paths if _path.is_file()]):
+        invalid_dist_list = ', '.join(map(str, invalid_dists))
+        die(
+            'The following paths look like distributions but '
+            f'are not actually files: {invalid_dist_list}',
+        )
 
     with SigningContext.production().signer(identity, cache=True) as s:
         debug(f'attesting to dists: {dist_paths}')

--- a/attestations.py
+++ b/attestations.py
@@ -73,7 +73,7 @@ def get_identity_token() -> IdentityToken:
     return IdentityToken(oidc_token)
 
 
-if __name__ == '__main__':
+def main() -> None:
     packages_dir = Path(sys.argv[1])
 
     try:
@@ -87,17 +87,19 @@ if __name__ == '__main__':
         die(cause)
 
     # Collect all sdists and wheels.
-    dists = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
-    dists.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
+    dist_paths = [sdist.absolute() for sdist in packages_dir.glob('*.tar.gz')]
+    dist_paths.extend(whl.absolute() for whl in packages_dir.glob('*.whl'))
 
     # Make sure everything that looks like a dist actually is one.
     # We do this up-front to prevent partial signing.
-    for dist in dists:
-        if not dist.is_file():
-            die(f'Path looks like a distribution but is not a file: {dist}')
-
+    for dist_path in dist_paths:
+        if not dist_path.is_file():
+            die(f'Path looks like a distribution but is not a file: {dist_path}')
 
     with SigningContext.production().signer(identity, cache=True) as s:
-        debug(f'attesting to dists: {dists}')
-        for dist in dists:
-            attest_dist(dist, s)
+        debug(f'attesting to dists: {dist_paths}')
+        for dist_path in dist_paths:
+            attest_dist(dist_path, s)
+
+if __name__ == '__main__':
+    main()

--- a/attestations.py
+++ b/attestations.py
@@ -30,16 +30,8 @@ attestations for its inputs, but failed to do so.
 _TOKEN_RETRIEVAL_FAILED_MESSAGE = """
 OpenID Connect token retrieval failed: {identity_error}
 
-This generally indicates a workflow configuration error, such as insufficient
-permissions. Make sure that your workflow has `id-token: write` configured
-at the job level, e.g.:
-
-```yaml
-permissions:
-  id-token: write
-```
-
-Learn more at https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings.
+This failure occurred after a successful Trusted Publishing Flow,
+suggesting a transient error.
 """  # noqa: S105; not a password
 
 
@@ -88,7 +80,8 @@ try:
 except IdentityError as identity_error:
     # NOTE: We only perform attestations in trusted publishing flows, so we
     # don't need to re-check for the "PR from fork" error mode, only
-    # generic token retrieval errors.
+    # generic token retrieval errors. We also render a simpler error,
+    # since permissions can't be to blame at this stage.
     cause = _TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error)
     die(cause)
 

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models == 0.0.2
+pypi-attestation-models == 0.0.4
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models >= 0.0.5, < 0.1.0
+pypi-attestation-models ~= 0.0.5
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models ~= 0.0.5
+pypi-attestations ~= 0.0.6
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.9
-sigstore ~= 3.0.0
+pypi-attestations ~= 0.0.10
+sigstore ~= 3.1.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,9 +1,14 @@
 twine
 
-# NOTE: Used to detect an ambient OIDC credential for OIDC publishing.
+# NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
+# as well as PEP 740 attestations.
 id ~= 1.0
 
 # NOTE: This is pulled in transitively through `twine`, but we also declare
 # NOTE: it explicitly here because `oidc-exchange.py` uses it.
 # Ref: https://github.com/di/id
 requests
+
+# NOTE: Used to generate attestations.
+pypi-attestation-models == 0.0.2
+sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.10
-sigstore ~= 3.1.0
+pypi-attestations ~= 0.0.11
+sigstore ~= 3.2.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models >= 0.0.4, < 0.1.0
+pypi-attestation-models >= 0.0.5, < 0.1.0
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,7 +1,7 @@
 twine
 
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
-# as well as PEP 740 attestations.
+# NOTE: as well as PEP 740 attestations.
 id ~= 1.0
 
 # NOTE: This is pulled in transitively through `twine`, but we also declare

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.8
+pypi-attestations ~= 0.0.9
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.6
+pypi-attestations ~= 0.0.8
 sigstore ~= 3.0.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,5 +10,5 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestation-models == 0.0.4
+pypi-attestation-models >= 0.0.4, < 0.1.0
 sigstore ~= 3.0.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.3.2
 cryptography==42.0.7
     # via
     #   pyopenssl
-    #   pypi-attestation-models
+    #   pypi-attestations
     #   sigstore
 dnspython==2.6.1
     # via email-validator
@@ -64,7 +64,7 @@ multidict==6.0.5
 nh3==0.2.17
     # via readme-renderer
 packaging==24.1
-    # via pypi-attestation-models
+    # via pypi-attestations
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -76,7 +76,7 @@ pycparser==2.22
 pydantic==2.7.1
     # via
     #   id
-    #   pypi-attestation-models
+    #   pypi-attestations
     #   sigstore
     #   sigstore-rekor-types
 pydantic-core==2.18.2
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestation-models==0.0.5
+pypi-attestations==0.0.6
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -118,10 +118,10 @@ securesystemslib==1.0.0
 sigstore==3.0.0
     # via
     #   -r runtime.in
-    #   pypi-attestation-models
+    #   pypi-attestations
 sigstore-protobuf-specs==0.3.2
     # via
-    #   pypi-attestation-models
+    #   pypi-attestations
     #   sigstore
 sigstore-rekor-types==0.0.13
     # via sigstore

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestation-models==0.0.4
+pypi-attestation-models==0.0.5
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.6
+pypi-attestations==0.0.8
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -63,6 +63,8 @@ multidict==6.0.5
     # via grpclib
 nh3==0.2.17
     # via readme-renderer
+packaging==24.1
+    # via pypi-attestation-models
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -87,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestation-models==0.0.2
+pypi-attestation-models==0.0.4
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -118,7 +120,9 @@ sigstore==3.0.0
     #   -r runtime.in
     #   pypi-attestation-models
 sigstore-protobuf-specs==0.3.2
-    # via sigstore
+    # via
+    #   pypi-attestation-models
+    #   sigstore
 sigstore-rekor-types==0.0.13
     # via sigstore
 six==1.16.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -95,7 +95,7 @@ python-dateutil==2.9.0.post0
     # via betterproto
 readme-renderer==43.0
     # via twine
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r runtime.in
     #   id
@@ -129,7 +129,7 @@ six==1.16.0
     # via python-dateutil
 tuf==5.0.0
     # via sigstore
-twine==5.1.0
+twine==5.1.1
     # via -r runtime.in
 typing-extensions==4.11.0
     # via

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.9
+pypi-attestations==0.0.10
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -115,7 +115,7 @@ rich==13.7.1
     #   twine
 securesystemslib==1.0.0
     # via tuf
-sigstore==3.0.0
+sigstore==3.1.0
     # via
     #   -r runtime.in
     #   pypi-attestations

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.8
+pypi-attestations==0.0.9
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -89,7 +89,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.10
+pypi-attestations==0.0.11
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -115,7 +115,7 @@ rich==13.7.1
     #   twine
 securesystemslib==1.0.0
     # via tuf
-sigstore==3.1.0
+sigstore==3.2.0
     # via
     #   -r runtime.in
     #   pypi-attestations

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,8 @@
 #
 annotated-types==0.6.0
     # via pydantic
+betterproto==2.0.0b6
+    # via sigstore-protobuf-specs
 certifi==2024.2.2
     # via requests
 cffi==1.16.0
@@ -13,13 +15,32 @@ cffi==1.16.0
 charset-normalizer==3.3.2
     # via requests
 cryptography==42.0.7
-    # via secretstorage
+    # via
+    #   pyopenssl
+    #   pypi-attestation-models
+    #   sigstore
+dnspython==2.6.1
+    # via email-validator
 docutils==0.21.2
     # via readme-renderer
+email-validator==2.1.1
+    # via pydantic
+grpclib==0.4.7
+    # via betterproto
+h2==4.1.0
+    # via grpclib
+hpack==4.0.0
+    # via h2
+hyperframe==6.0.1
+    # via h2
 id==1.4.0
-    # via -r runtime.in
+    # via
+    #   -r runtime.in
+    #   sigstore
 idna==3.7
-    # via requests
+    # via
+    #   email-validator
+    #   requests
 importlib-metadata==7.1.0
     # via twine
 jaraco-classes==3.4.0
@@ -28,10 +49,6 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==25.2.1
     # via twine
 markdown-it-py==3.0.0
@@ -42,20 +59,38 @@ more-itertools==10.2.0
     # via
     #   jaraco-classes
     #   jaraco-functools
+multidict==6.0.5
+    # via grpclib
 nh3==0.2.17
     # via readme-renderer
 pkginfo==1.10.0
     # via twine
+platformdirs==4.2.2
+    # via sigstore
+pyasn1==0.6.0
+    # via sigstore
 pycparser==2.22
     # via cffi
 pydantic==2.7.1
-    # via id
+    # via
+    #   id
+    #   pypi-attestation-models
+    #   sigstore
+    #   sigstore-rekor-types
 pydantic-core==2.18.2
     # via pydantic
 pygments==2.18.0
     # via
     #   readme-renderer
     #   rich
+pyjwt==2.8.0
+    # via sigstore
+pyopenssl==24.1.0
+    # via sigstore
+pypi-attestation-models==0.0.2
+    # via -r runtime.in
+python-dateutil==2.9.0.post0
+    # via betterproto
 readme-renderer==43.0
     # via twine
 requests==2.31.0
@@ -63,15 +98,33 @@ requests==2.31.0
     #   -r runtime.in
     #   id
     #   requests-toolbelt
+    #   sigstore
+    #   tuf
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
+rfc8785==0.1.2
+    # via sigstore
 rich==13.7.1
-    # via twine
-secretstorage==3.3.3
-    # via keyring
+    # via
+    #   sigstore
+    #   twine
+securesystemslib==1.0.0
+    # via tuf
+sigstore==3.0.0
+    # via
+    #   -r runtime.in
+    #   pypi-attestation-models
+sigstore-protobuf-specs==0.3.2
+    # via sigstore
+sigstore-rekor-types==0.0.13
+    # via sigstore
+six==1.16.0
+    # via python-dateutil
+tuf==5.0.0
+    # via sigstore
 twine==5.1.0
     # via -r runtime.in
 typing-extensions==4.11.0

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -64,10 +64,13 @@ The workflow was run with 'attestations: true', but the specified repository URL
 does not support PEP 740 attestations. As a result, the attestations setting \
 is ignored."
 
+[[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
+    && TRUSTED_PUBLISHING=true || TRUSTED_PUBLISHING=false
+
 if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
-    # Setting `attestations: true` and explicitly passing a password indicates
-    # user confusion, since attestations (currently) require Trusted Publishing.
-    if [[ -n "${INPUT_PASSWORD}" ]] ; then
+    # Setting `attestations: true` without Trusted Publishing indicates
+    # user confusion, since attestations (currently) require it.
+    if ! "${TRUSTED_PUBLISHING}" ; then
         echo "${ATTESTATIONS_WITHOUT_TP_WARNING}"
         INPUT_ATTESTATIONS="false"
     fi
@@ -81,7 +84,7 @@ if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
     fi
 fi
 
-if [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] ; then
+if "${TRUSTED_PUBLISHING}" ; then
     # No password supplied by the user implies that we're in the OIDC flow;
     # retrieve the OIDC credential and exchange it for a PyPI API token.
     echo "::debug::Authenticating to ${INPUT_REPOSITORY_URL} via Trusted Publishing"

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -55,14 +55,14 @@ combinations or API tokens to authenticate with PyPI. Read more: \
 https://docs.pypi.org/trusted-publishers"
 
 ATTESTATIONS_WITHOUT_TP_WARNING="::warning title=attestations setting ignored::\
-The workflow was run with 'attestations: true', but an explicit password was \
-also supplied, disabling Trusted Publishing. As a result, the attestations \
-setting is ignored."
+The workflow was run with the 'attestations: true' setting, but an explicit \
+password was also set, disabling Trusted Publishing. As a result, the \
+attestations setting is ignored."
 
 ATTESTATIONS_WRONG_INDEX_WARNING="::warning title=attestations setting ignored::\
-The workflow was run with 'attestations: true', but the specified repository URL \
-does not support PEP 740 attestations. As a result, the attestations setting \
-is ignored."
+The workflow was run with 'attestations: true' setting, but the specified \
+repository URL does not support PEP 740 attestations. As a result, the \
+attestations setting is ignored."
 
 [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
     && TRUSTED_PUBLISHING=true || TRUSTED_PUBLISHING=false

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -39,6 +39,7 @@ INPUT_PACKAGES_DIR="$(get-normalized-input 'packages-dir')"
 INPUT_VERIFY_METADATA="$(get-normalized-input 'verify-metadata')"
 INPUT_SKIP_EXISTING="$(get-normalized-input 'skip-existing')"
 INPUT_PRINT_HASH="$(get-normalized-input 'print-hash')"
+INPUT_ATTESTATIONS="$(get-normalized-input 'attestations')"
 
 PASSWORD_DEPRECATION_NUDGE="::error title=Password-based uploads disabled::\
 As of 2024, PyPI requires all users to enable Two-Factor \
@@ -52,6 +53,33 @@ Trusted Publishers allows publishing packages to PyPI from automated \
 environments like GitHub Actions without needing to use username/password \
 combinations or API tokens to authenticate with PyPI. Read more: \
 https://docs.pypi.org/trusted-publishers"
+
+ATTESTATIONS_WITHOUT_TP_WARNING="::warning title=attestations setting ignored::\
+The workflow was run with 'attestations: true', but an explicit password was \
+also supplied, disabling Trusted Publishing. As a result, the attestations \
+setting is ignored."
+
+ATTESTATIONS_WRONG_INDEX_WARNING="::warning title=attestations setting ignored::\
+The workflow was run with 'attestations: true', but the specified repository URL \
+does not support PEP 740 attestations. As a result, the attestations setting \
+is ignored."
+
+if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
+    # Setting `attestations: true` and explicitly passing a password indicates
+    # user confusion, since attestations (currently) require Trusted Publishing.
+    if [[ -n "${INPUT_PASSWORD}" ]] ; then
+        echo "${ATTESTATIONS_WITHOUT_TP_WARNING}"
+        INPUT_ATTESTATIONS="false"
+    fi
+
+    # Setting `attestations: true` with an index other than PyPI or TestPyPI
+    # indicates user confusion, since attestations are not supported on other
+    # indices presently.
+    if [[ ! "${INPUT_REPOSITORY_URL}" =~ pypi\.org ]] ; then
+        echo "${ATTESTATIONS_WRONG_INDEX_WARNING}"
+        INPUT_ATTESTATIONS="false"
+    fi
+fi
 
 if [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] ; then
     # No password supplied by the user implies that we're in the OIDC flow;
@@ -128,6 +156,15 @@ fi
 
 if [[ ${INPUT_VERBOSE,,} != "false" ]] ; then
     TWINE_EXTRA_ARGS="--verbose $TWINE_EXTRA_ARGS"
+fi
+
+if [[ ${INPUT_ATTESTATIONS,,} != "false" ]] ; then
+    # NOTE: Intentionally placed after `twine check`, to prevent attestation
+    # generation on distributions with invalid metadata.
+    echo "::debug::Generating and uploading PEP 740 attestations"
+    python /app/attestations.py "${INPUT_PACKAGES_DIR%%/}"
+
+    TWINE_EXTRA_ARGS="--attestations $TWINE_EXTRA_ARGS"
 fi
 
 if [[ ${INPUT_PRINT_HASH,,} != "false" || ${INPUT_VERBOSE,,} != "false" ]] ; then

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -161,7 +161,7 @@ fi
 if [[ ${INPUT_ATTESTATIONS,,} != "false" ]] ; then
     # NOTE: Intentionally placed after `twine check`, to prevent attestation
     # generation on distributions with invalid metadata.
-    echo "::debug::Generating and uploading PEP 740 attestations"
+    echo "::notice::Generating and uploading digital attestations"
     python /app/attestations.py "${INPUT_PACKAGES_DIR%%/}"
 
     TWINE_EXTRA_ARGS="--attestations $TWINE_EXTRA_ARGS"

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -54,15 +54,15 @@ environments like GitHub Actions without needing to use username/password \
 combinations or API tokens to authenticate with PyPI. Read more: \
 https://docs.pypi.org/trusted-publishers"
 
-ATTESTATIONS_WITHOUT_TP_WARNING="::warning title=attestations setting ignored::\
-The workflow was run with the 'attestations: true' setting, but an explicit \
+ATTESTATIONS_WITHOUT_TP_WARNING="::warning title=attestations input ignored::\
+The workflow was run with the 'attestations: true' input, but an explicit \
 password was also set, disabling Trusted Publishing. As a result, the \
-attestations setting is ignored."
+attestations input is ignored."
 
-ATTESTATIONS_WRONG_INDEX_WARNING="::warning title=attestations setting ignored::\
-The workflow was run with 'attestations: true' setting, but the specified \
+ATTESTATIONS_WRONG_INDEX_WARNING="::warning title=attestations input ignored::\
+The workflow was run with 'attestations: true' input, but the specified \
 repository URL does not support PEP 740 attestations. As a result, the \
-attestations setting is ignored."
+attestations input is ignored."
 
 [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
     && TRUSTED_PUBLISHING=true || TRUSTED_PUBLISHING=false

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -163,7 +163,7 @@ fi
 
 if [[ ${INPUT_ATTESTATIONS,,} != "false" ]] ; then
     # NOTE: Intentionally placed after `twine check`, to prevent attestation
-    # generation on distributions with invalid metadata.
+    # NOTE: generation on distributions with invalid metadata.
     echo "::notice::Generating and uploading digital attestations"
     python /app/attestations.py "${INPUT_PACKAGES_DIR%%/}"
 


### PR DESCRIPTION
~~WIP, still experimenting here. Not ready for review 🙂~~

This adds PEP 740 attestation generation to the workflow: when the Trusted Publishing flow is used, this will generate a publish attestation for each distribution being uploaded. These generated attestations are then fed into `twine`, which newly supports them via `--attestations`.

Breakdown:

- [x] Generate attestations for each dist
- [x] Actually hook up `twine --attestations`
- [x] Documentation

See: https://github.com/pypi/warehouse/issues/15871