### PR TITLE
Add Docker label for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim
 LABEL "maintainer" "Sviatoslav Sydorenko <wk+pypa@sydorenko.org.ua>"
 LABEL "repository" "https://github.com/pypa/gh-action-pypi-publish"
 LABEL "homepage" "https://github.com/pypa/gh-action-pypi-publish"
+LABEL "org.opencontainers.image.source" "https://github.com/pypa/gh-action-pypi-publish"
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
This PR will add the [label `org.opencontainers.image.source`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images) to the Dockerfile. This label helps link [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (GHCR) with the associated repo.

https://github.com/pypa/gh-action-pypi-publish/pull/230/files#r1603926630
