### PR TITLE
requirements: re-compile requirements with latest twine

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -8,12 +8,8 @@ annotated-types==0.6.0
     # via pydantic
 certifi==2024.2.2
     # via requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==42.0.7
-    # via secretstorage
 docutils==0.21.2
     # via readme-renderer
 id==1.4.0
@@ -28,10 +24,6 @@ jaraco-context==5.3.0
     # via keyring
 jaraco-functools==4.0.1
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==25.2.1
     # via twine
 markdown-it-py==3.0.0
@@ -46,8 +38,6 @@ nh3==0.2.17
     # via readme-renderer
 pkginfo==1.10.0
     # via twine
-pycparser==2.22
-    # via cffi
 pydantic==2.7.1
     # via id
 pydantic-core==2.18.2
@@ -70,8 +60,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 twine==5.1.0
     # via -r runtime.in
 typing-extensions==4.11.0


### PR DESCRIPTION
Per #236: this re-compiles `requirements.txt` to shave off a few dependencies that are no longer in `twine`'s transitive closure.

(Some, but not all, of these will come back with #236, like `cryptography`.)