### PR TITLE
Update Dockerfile - Docker has set rate limits on pulls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM public.ecr.aws/docker/library/python:3.12.5-slim-bookworm
 
 LABEL "maintainer" "Sviatoslav Sydorenko <wk+pypa@sydorenko.org.ua>"
 LABEL "repository" "https://github.com/pypa/gh-action-pypi-publish"


### PR DESCRIPTION
Docker have implemented rate limiting on pulls, this results in failing builds with errors like: message": "You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
" then this is the reason. A quick fix is to use Amazon ECR - you can find it here: https://gallery.ecr.aws/
in most cases you can simply prefix your image-refs with public.ecr.aws/docker/library.