### PR TITLE
Remove redundant `Path.absolute()` call

### DIFF
--- a/print-hash.py
+++ b/print-hash.py
@@ -2,7 +2,7 @@ import hashlib
 import pathlib
 import sys
 
-packages_dir = pathlib.Path(sys.argv[1]).resolve().absolute()
+packages_dir = pathlib.Path(sys.argv[1]).resolve()
 
 print('Showing hash values of files to be uploaded:')
 


### PR DESCRIPTION
As pointed out in this open PR: https://github.com/pypa/gh-action-pypi-publish/pull/250#pullrequestreview-2274163721, `Path.resolve().absolute()` is redundant. This removes an occurrence of it in the codebase.