### PR TITLE
Bump `pypi-attestations` to v0.0.12 in the runtime lock file

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,7 +10,7 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.11
+pypi-attestations ~= 0.0.12
 sigstore ~= 3.2.0
 
 # NOTE: Used to detect the PyPI package name from the distribution files

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -91,7 +91,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.11
+pypi-attestations==0.0.12
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto


### PR DESCRIPTION
This is a small dep bump, following a discovery we made in https://github.com/trailofbits/pypi-attestations/pull/48 -- Pydantic's default Base64 encode/decode inserts newlines every 76 characters (https://github.com/pydantic/pydantic/issues/9072#issuecomment-2361185555), resulting in encodings that aren't valid "plain" base64 and that aren't consistent with what PEP 740 stipulates.

The good news is that this isn't _too_ problematic since PyPI hasn't persisted any (malformed) attestations yet; the bad news is that it requires this bump 🙂 

CC @facutuesca for visibility