### PR TITLE
Fix magic link summary

### DIFF
--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -73,7 +73,11 @@ MAGIC_LINK_MESSAGE="::warning title=Create a Trusted Publisher::\
 A new Trusted Publisher for the currently running publishing workflow can be created \
 by accessing the following link(s) while logged-in as an owner of the package(s):"
 
-if [[ ! "${INPUT_REPOSITORY_URL}" =~ pypi\.org || ${#PACKAGE_NAMES[@]} -eq 0 ]] ; then
+
+[[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
+    && TRUSTED_PUBLISHING=true || TRUSTED_PUBLISHING=false
+
+if [[ "${TRUSTED_PUBLISHING}" == true || ! "${INPUT_REPOSITORY_URL}" =~ pypi\.org || ${#PACKAGE_NAMES[@]} -eq 0 ]] ; then
     TRUSTED_PUBLISHING_MAGIC_LINK_NUDGE=""
 else
     if [[ "${INPUT_REPOSITORY_URL}" =~ test\.pypi\.org ]] ; then
@@ -90,8 +94,6 @@ else
     echo "${MAGIC_LINK_MESSAGE}" >> $GITHUB_STEP_SUMMARY
 fi
 
-[[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
-    && TRUSTED_PUBLISHING=true || TRUSTED_PUBLISHING=false
 
 if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
     # Setting `attestations: true` without Trusted Publishing indicates

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -69,9 +69,9 @@ The workflow was run with 'attestations: true' input, but the specified \
 repository URL does not support PEP 740 attestations. As a result, the \
 attestations input is ignored."
 
-MAGIC_LINK_MESSAGE="::warning title=Create a Trusted Publisher::\
-A new Trusted Publisher for the currently running publishing workflow can be created \
-by accessing the following link(s) while logged-in as an owner of the package(s):"
+MAGIC_LINK_MESSAGE="A new Trusted Publisher for the currently running \
+publishing workflow can be created by accessing the following link(s) while \
+logged-in as an owner of the package(s):"
 
 
 [[ "${INPUT_USER}" == "__token__" && -z "${INPUT_PASSWORD}" ]] \
@@ -90,10 +90,14 @@ else
         LINK="- ${INDEX_URL}/manage/project/${PACKAGE_NAME}/settings/publishing/?provider=github&owner=${GITHUB_REPOSITORY_OWNER}&repository=${REPOSITORY_NAME}&workflow_filename=${WORKFLOW_FILENAME}"
         ALL_LINKS+="$LINK"$'\n'
     done
-    TRUSTED_PUBLISHING_MAGIC_LINK_NUDGE="${MAGIC_LINK_MESSAGE}"$'\n'"${ALL_LINKS}"
-    echo "${MAGIC_LINK_MESSAGE}" >> $GITHUB_STEP_SUMMARY
-fi
 
+    # Construct the summary message without the warning header
+    MAGIC_LINK_MESSAGE_WITH_LINKS="${MAGIC_LINK_MESSAGE}"$'\n'"${ALL_LINKS}"
+    echo "${MAGIC_LINK_MESSAGE_WITH_LINKS}" >> $GITHUB_STEP_SUMMARY
+
+    # The actual nudge in the log is formatted as a warning
+    TRUSTED_PUBLISHING_MAGIC_LINK_NUDGE="::warning title=Create a Trusted Publisher::${MAGIC_LINK_MESSAGE_WITH_LINKS}"
+fi
 
 if [[ "${INPUT_ATTESTATIONS}" != "false" ]] ; then
     # Setting `attestations: true` without Trusted Publishing indicates


### PR DESCRIPTION
This PR fixes a few issues in the magic link nudge logic:

1. Part of the nudge is printed in the summary even if Trusted Publishing is used
2. The summary message includes the `::warning...` tag, which only works for the logs, not for the summary
3. The summary message does not include the magic links

See [this job](https://github.com/trailofbits/rfc8785.py/actions/runs/11074320876/attempts/1#summary-30772845248) for an example of all 3 issues. The workflow uses Trusted Publishing, but the nudge is still included in the summary, with the `::warning` tag and no magic links.

This PR fixes the issues by:
- Not adding the nudge to the job summary when using Trusted Publishing
- Constructing the summary without the `::warning` tag
- Adding the magic links to the summary


cc @woodruffw @webknjaz 

