### PR TITLE
Update `actions/checkout` to v3 in self-tests

### DIFF
--- a/.github/workflows/self-smoke-test-action.yml
+++ b/.github/workflows/self-smoke-test-action.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Check out the action locally
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: test
     - name: Install the packaging-related tools


### PR DESCRIPTION
actions/checkout@v3 use node.js version 16. But version 16 is deprecated. Chechout version 4 fixes the problem.