### PR TITLE
requirements: bump sigstore, pypi-attestations

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,8 +10,8 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.12
-sigstore ~= 3.2.0
+pypi-attestations ~= 0.0.13
+sigstore ~= 3.4.0
 
 # NOTE: Used to detect the PyPI package name from the distribution files
 packaging

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -11,7 +11,7 @@ requests
 
 # NOTE: Used to generate attestations.
 pypi-attestations ~= 0.0.13
-sigstore ~= 3.4.0
+sigstore ~= 3.5.1
 
 # NOTE: Used to detect the PyPI package name from the distribution files
 packaging

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -119,7 +119,7 @@ rich==13.7.1
     #   twine
 securesystemslib==1.0.0
     # via tuf
-sigstore==3.4.0
+sigstore==3.5.1
     # via
     #   -r runtime.in
     #   pypi-attestations

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -72,7 +72,9 @@ pkginfo==1.10.0
 platformdirs==4.2.2
     # via sigstore
 pyasn1==0.6.0
-    # via sigstore
+    # via
+    #   pypi-attestations
+    #   sigstore
 pycparser==2.22
     # via cffi
 pydantic==2.7.1
@@ -91,7 +93,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.12
+pypi-attestations==0.0.13
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -117,7 +119,7 @@ rich==13.7.1
     #   twine
 securesystemslib==1.0.0
     # via tuf
-sigstore==3.2.0
+sigstore==3.4.0
     # via
     #   -r runtime.in
     #   pypi-attestations


### PR DESCRIPTION
Bumps sigstore-python to ~3.4 and pypi-attestations to the latest point.

This should have no functional changes for this workflow, since the only changes are to the verifying APIs.