### PR TITLE
action: enable attestations by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ inputs:
       Enable experimental support for PEP 740 attestations.
       Only works with PyPI and TestPyPI via Trusted Publishing.
     required: false
-    default: 'false'
+    default: 'true'
 branding:
   color: yellow
   icon: upload-cloud


### PR DESCRIPTION
Attestations have been live and stable on PyPI and TestPyPI for a few weeks now, so I think we're good to flip the default here 🙂 
