### PR TITLE
requirements: bump pypi-attestations to 0.0.15

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -10,7 +10,7 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.13
+pypi-attestations ~= 0.0.15
 sigstore ~= 3.5.1
 
 # NOTE: Used to detect the PyPI package name from the distribution files

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -93,7 +93,7 @@ pyjwt==2.8.0
     # via sigstore
 pyopenssl==24.1.0
     # via sigstore
-pypi-attestations==0.0.13
+pypi-attestations==0.0.15
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto


### PR DESCRIPTION
This fixes https://github.com/pypa/gh-action-pypi-publish/pull/295#issuecomment-2460922367 via https://github.com/trailofbits/pypi-attestations/pull/68.