### PR TITLE
Tag Docker images with Git SHA

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -32,15 +32,18 @@ jobs:
         IMAGE="ghcr.io/$GITHUB_REPOSITORY:${DOCKER_TAG}"
         IMAGE_MAJOR="ghcr.io/$GITHUB_REPOSITORY:${DOCKER_TAG_MAJOR}"
         IMAGE_MAJOR_MINOR="ghcr.io/$GITHUB_REPOSITORY:${DOCKER_TAG_MAJOR_MINOR}"
+        IMAGE_SHA="ghcr.io/$GITHUB_REPOSITORY:${GITHUB_SHA}"
         echo "IMAGE=$IMAGE" >>"$GITHUB_ENV"
         echo "IMAGE_MAJOR=$IMAGE_MAJOR" >>"$GITHUB_ENV"
         echo "IMAGE_MAJOR_MINOR=$IMAGE_MAJOR_MINOR" >>"$GITHUB_ENV"
+        echo "IMAGE_SHA=$IMAGE_SHA" >>"$GITHUB_ENV"
         docker build . \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --cache-from $IMAGE \
           --tag $IMAGE
         docker tag $IMAGE $IMAGE_MAJOR
         docker tag $IMAGE $IMAGE_MAJOR_MINOR
+        docker tag $IMAGE $IMAGE_SHA
       env:
         DOCKER_TAG: ${{ inputs.tag || github.ref_name }}
     - name: Log in to GHCR
@@ -52,3 +55,4 @@ jobs:
         docker push $IMAGE
         docker push $IMAGE_MAJOR
         docker push $IMAGE_MAJOR_MINOR
+        docker push $IMAGE_SHA


### PR DESCRIPTION
## Description

Closes https://github.com/pypa/gh-action-pypi-publish/issues/290

PR https://github.com/pypa/gh-action-pypi-publish/pull/230 updated the action to pull Docker images from GHCR instead of building Docker images each time the workflow runs. As part of this PR, a new GitHub Actions workflow was added that builds Docker images and pushes them to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (GHCR).

[Actions can be referenced in various ways](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow).

The Docker build workflow covers most of the action references, but does not push Docker images tagged with the Git commit ID (Git SHA).

## Changes

This PR will add Docker tags for [referencing the action with a Git SHA](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow#using-shas).

GitHub Actions only supports references by the full 40 character SHA. If users try to reference the action by a short SHA like `1234567`, they will get an error like, "Unable to resolve action `pypa/gh-action-pypi-publish@1234567`, the provided ref `1234567` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `1234567890123456789012345678901234567890` instead."

## Related

- https://github.com/pypa/gh-action-pypi-publish/pull/230
- https://github.com/pypa/gh-action-pypi-publish/issues/290
- [GitHub docs: Actions - Write workflows - Choose what workflows do - Using pre-written building blocks in your workflow](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow)
