### PR TITLE
Support nested composite actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,20 @@ inputs:
       Only works with PyPI and TestPyPI via Trusted Publishing.
     required: false
     default: 'true'
+  action_repository:
+    description: >-
+      [EXPERIMENTAL]
+      Set action repository to work around bug in nested composite actions
+      https://github.com/actions/runner/issues/2473
+    required: false
+    default: ${{ github.action_repository }}
+  action_ref:
+    description: >-
+      [EXPERIMENTAL]
+      Set action ref to work around bug in nested composite actions
+      https://github.com/actions/runner/issues/2473
+    required: false
+    default: ${{ github.action_ref }}
 branding:
   color: yellow
   icon: upload-cloud
@@ -116,17 +130,19 @@ runs:
     run: |
       # Set repo and ref from which to run Docker container action
       # to handle cases in which `github.action_` context is not set
+      # or set properly for nested composite actions
       # https://github.com/actions/runner/issues/2473
       REF=${{ env.ACTION_REF || env.PR_REF || github.ref_name }}
       REPO=${{ env.ACTION_REPO || env.PR_REPO || github.repository }}
       REPO_ID=${{ env.PR_REPO_ID || github.repository_id }}
+      echo "action-path=$ACTION_PATH" >>"$GITHUB_OUTPUT"
       echo "ref=$REF" >>"$GITHUB_OUTPUT"
       echo "repo=$REPO" >>"$GITHUB_OUTPUT"
       echo "repo-id=$REPO_ID" >>"$GITHUB_OUTPUT"
     shell: bash
     env:
-      ACTION_REF: ${{ github.action_ref }}
-      ACTION_REPO: ${{ github.action_repository }}
+      ACTION_REF: ${{ inputs.action_ref }}
+      ACTION_REPO: ${{ inputs.action_repository }}
       PR_REF: ${{ github.event.pull_request.head.ref }}
       PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       PR_REPO_ID: ${{ github.event.pull_request.base.repo.id }}


### PR DESCRIPTION
## Description

To reference metadata about [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action), GitHub Actions provides the `github.action_` [context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context), including `github.action_ref` and `github.action_repository`.

GitHub Actions supports nested composite actions with a recursion limit of 9 (9 nested composite actions). Unfortunately `github.action_` values are not propagated correctly when running nested composite actions (https://github.com/actions/runner/issues/2473#issuecomment-1776029708). This is a bug in the GitHub Actions runner.

## Changes

This PR will implement the suggested workaround from https://github.com/actions/runner/issues/2473#issuecomment-1776051383. The action will use inputs to set the correct values.

## Related

- https://github.com/pypa/gh-action-pypi-publish/issues/291
- https://github.com/pypa/gh-action-pypi-publish/issues/299
- https://github.com/pypa/gh-action-pypi-publish/issues/300
- [actions/runner/docs/adrs/1144-composite-actions.md](https://github.com/actions/runner/blob/6ef5803f24724b77a8d3599a478d06018da5d7c6/docs/adrs/1144-composite-actions.md?plain=1#L27) (note that ADR 1144 says the recursion limit is 10, not 9)
- https://github.com/actions/runner/issues/646#issuecomment-901336347 (composite action recursion limit of 9)
- https://github.com/actions/runner/issues/862#issuecomment-901339571 (composite action recursion limit of 9)
- https://github.com/actions/runner/issues/2473#issuecomment-1776029708
- https://github.com/github/docs/issues/25336#issuecomment-1736251764
