### PR TITLE
oidc-exchange: add workflow_ref to debug msg

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -83,6 +83,7 @@ If a claim is not present in the claim set, then it is rendered as `MISSING`.
 * `repository`: `{repository}`
 * `repository_owner`: `{repository_owner}`
 * `repository_owner_id`: `{repository_owner_id}`
+* `workflow_ref`: `{workflow_ref}`
 * `job_workflow_ref`: `{job_workflow_ref}`
 * `ref`: `{ref}`
 
@@ -175,6 +176,7 @@ def render_claims(token: str) -> str:
         repository=_get('repository'),
         repository_owner=_get('repository_owner'),
         repository_owner_id=_get('repository_owner_id'),
+        workflow_ref=_get('workflow_ref'),
         job_workflow_ref=_get('job_workflow_ref'),
         ref=_get('ref'),
     )


### PR DESCRIPTION
`workflow_ref` and `job_workflow_ref` diverge in the "reusable workflow from external repo" case, so having both in the debug output makes it a bit easier to root cause that kind of scenario 🙂 