### PR TITLE
runtime: bump pkginfo to ~1.12

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,5 +1,8 @@
 twine ~= 6.0
 
+# NOTE: 1.12.0 and later enable support for metadata 2.4
+pkginfo ~= 1.12.0
+
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
 # NOTE: as well as PEP 740 attestations.
 id ~= 1.0

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,6 +1,8 @@
 twine ~= 6.0
 
 # NOTE: 1.12.0 and later enable support for metadata 2.4
+# NOTE: This can be dropped once twine stops using pkginfo
+# Ref: https://github.com/pypa/twine/pull/1180
 pkginfo ~= 1.12.0
 
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -66,8 +66,10 @@ packaging==24.1
     #   -r runtime.in
     #   pypi-attestations
     #   twine
-pkginfo==1.10.0
-    # via twine
+pkginfo==1.12.0
+    # via
+    #   -r runtime.in
+    #   twine
 platformdirs==4.2.2
     # via sigstore
 pyasn1==0.6.0


### PR DESCRIPTION
This follows #309 and should fix the metadata issues more thoroughly, since pkginfo 1.12 includes support for metadata 2.4.

See #310

CC @webknjaz 