### PR TITLE
🐛 Add support for uploading dists with metadata v2.4

### DIFF
--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -96,6 +96,24 @@ jobs:
           readme = "README.md"
     - name: Build the stub package sdist and wheel distributions
       run: python3 -m build
+    - name: Create the Rust package directory
+      run: mkdir -pv rust-example
+    - name: Initialize a Rust project
+      run: cargo init
+      working-directory: rust-example
+    - name: Populate the Rust package `pyproject.toml`
+      run: echo "$CONTENTS" > pyproject.toml
+      env:
+        CONTENTS: |
+          [build-system]
+          requires = [
+            "maturin ~=1.0",
+          ]
+          build-backend = "maturin"
+      working-directory: rust-example
+    - name: Build the stub package sdist and wheel distributions
+      run: python3 -m build -o ../dist/
+      working-directory: rust-example
     - name: Register the stub package in devpi
       run: |
         for dist in dist/*.tar.gz

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -97,7 +97,12 @@ jobs:
     - name: Build the stub package sdist and wheel distributions
       run: python3 -m build
     - name: Register the stub package in devpi
-      run: twine register dist/*.tar.gz
+      run: |
+        for dist in dist/*.tar.gz
+        do
+          echo "Registering ${dist}..."
+          twine register "${dist}"
+        done
       env:
         TWINE_USERNAME: ${{ env.devpi-username }}
         TWINE_PASSWORD: ${{ env.devpi-password }}

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,5 +1,10 @@
 twine ~= 6.0
 
+# NOTE: 1.12.0 and later enable support for metadata 2.4
+# NOTE: This can be dropped once twine stops using pkginfo
+# Ref: https://github.com/pypa/twine/pull/1180
+pkginfo ~= 1.12.0
+
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
 # NOTE: as well as PEP 740 attestations.
 id ~= 1.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -66,8 +66,10 @@ packaging==24.1
     #   -r runtime.in
     #   pypi-attestations
     #   twine
-pkginfo==1.10.0
-    # via twine
+pkginfo==1.12.0
+    # via
+    #   -r runtime.in
+    #   twine
 platformdirs==4.2.2
     # via sigstore
 pyasn1==0.6.0


### PR DESCRIPTION
This patch bumps the transitive package `pkgutil` to v1.12 to enable support for validating metadata v2.4 in Twine. It also integrates a Maturin-based package into the smoke test in CI as a regression check.

Closes #312
Resolves #311
Resolves #310