### PR TITLE
📦 Enable support for PEP 639 metadata

### DIFF
--- a/requirements/runtime-constraints.in
+++ b/requirements/runtime-constraints.in
@@ -13,8 +13,3 @@
 #      remain in Git.                                                         #
 #                                                                             #
 ###############################################################################
-
-# NOTE: 1.12.0 and later enable support for metadata 2.4
-# NOTE: This can be dropped once twine stops using pkginfo
-# Ref: https://github.com/pypa/twine/pull/1180
-pkginfo >= 1.12.0

--- a/requirements/runtime-constraints.in
+++ b/requirements/runtime-constraints.in
@@ -13,3 +13,7 @@
 #      remain in Git.                                                         #
 #                                                                             #
 ###############################################################################
+
+# NOTE: Twine 6.1 needs packaging 24.2 to support metadata 2.4
+# Ref: https://github.com/pypa/twine/pull/1180
+packaging >= 24.2

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,7 +1,7 @@
 -c runtime-constraints.in  # limits known broken versions
 
-# NOTE: v6 is needed to support metadata v2.4
-twine >= 6.0
+# NOTE: v6.1 is needed to support metadata v2.4 including PEP 639
+twine >= 6.1
 
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
 # NOTE: as well as PEP 740 attestations.

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -38,6 +38,7 @@ id==1.4.0
     # via
     #   -r runtime.in
     #   sigstore
+    #   twine
 idna==3.7
     # via
     #   email-validator
@@ -70,10 +71,6 @@ packaging==24.1
     # via
     #   -r runtime.in
     #   pypi-attestations
-    #   twine
-pkginfo==1.12.0
-    # via
-    #   -c runtime-constraints.in
     #   twine
 platformdirs==4.2.2
     # via sigstore
@@ -141,7 +138,7 @@ six==1.16.0
     # via python-dateutil
 tuf==5.0.0
     # via sigstore
-twine==6.0.1
+twine==6.1.0
     # via -r runtime.in
 typing-extensions==4.11.0
     # via

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -67,8 +67,9 @@ multidict==6.0.5
     # via grpclib
 nh3==0.2.17
     # via readme-renderer
-packaging==24.1
+packaging==24.2
     # via
+    #   -c runtime-constraints.in
     #   -r runtime.in
     #   pypi-attestations
     #   twine


### PR DESCRIPTION
This is achieved by upgrading Twine to v6.1.0. Prior to this version, Twine was unable to pick up and publish licensing information declared in the new `License-Expression` core packaging metadata [[1]] [[2]]. And now it does that.

Resolves #325.
Closes #326.

[1]: https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
[2]: https://peps.python.org/pep-0639/#spdx