### PR TITLE
Update pre-commit hooks and `additional_dependencies`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: add-trailing-comma
 
 - repo: https://github.com/PyCQA/isort.git
-  rev: 5.13.2
+  rev: 6.0.0
   hooks:
   - id: isort
     args:
@@ -22,7 +22,7 @@ repos:
   - id: remove-tabs
 
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
-  rev: 0.29.2
+  rev: 0.31.1
   hooks:
   - id: check-github-actions
   - id: check-github-workflows
@@ -37,7 +37,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   # Side-effects:
   - id: end-of-file-fixer
@@ -62,7 +62,7 @@ repos:
     language_version: python3
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.4.1
   hooks:
   - id: codespell
 
@@ -78,7 +78,7 @@ repos:
     - --strict
 
 - repo: https://github.com/PyCQA/flake8.git
-  rev: 7.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     args:
@@ -111,13 +111,12 @@ repos:
       WPS453,
     - --max-module-members=8  # WPS202
     additional_dependencies:
-    - flake8-2020 ~= 1.7.0
-    - flake8-pytest-style ~= 1.6.0
-    - wemake-python-styleguide ~= 0.19.0
-    language_version: python3.11  # flake8-commas doesn't work w/ Python 3.12
+    - flake8-2020 ~= 1.8.1
+    - flake8-pytest-style ~= 2.1.0
+    - wemake-python-styleguide ~= 1.0.0
 
 - repo: https://github.com/PyCQA/pylint.git
-  rev: v3.3.0
+  rev: v3.3.4
   hooks:
   - id: pylint
     args:


### PR DESCRIPTION
This addresses a small number of issues:

* isort 6 resolves pre-commit deprecation warnings about its use of hook names
* Several additional dependencies have new major versions
* A `language_version` was set to accommodate a flake8 plugin that is no longer listed in `additional_dependencies`

After these changes, no new warnings or errors appeared when running `pre-commit run -a`.