### PR TITLE
Fix duplicate attestations error message to be a str, not a tuple

### DIFF
--- a/attestations.py
+++ b/attestations.py
@@ -83,7 +83,7 @@ def assert_attestations_do_not_pre_exist(
     existing_attestations_list = '\n'.join(map(str, existing_attestations))
     error_message = (
         'The following distributions already have publish attestations:'
-        f'{existing_attestations_list}',
+        f'{existing_attestations_list}'
     )
     die(error_message)
 

--- a/attestations.py
+++ b/attestations.py
@@ -82,7 +82,7 @@ def assert_attestations_do_not_pre_exist(
 
     existing_attestations_list = '\n'.join(map(str, existing_attestations))
     error_message = (
-        'The following distributions already have publish attestations:'
+        'The following distributions already have publish attestations: '
         f'{existing_attestations_list}'
     )
     die(error_message)


### PR DESCRIPTION
I imagine someone refactored and moved message out int a variable, but forgot that in that case comma after argument is significant.

Fixes #339