### PR TITLE
oidc-exchange: include environment in rendered claims

### DIFF
--- a/oidc-exchange.py
+++ b/oidc-exchange.py
@@ -86,6 +86,7 @@ If a claim is not present in the claim set, then it is rendered as `MISSING`.
 * `workflow_ref`: `{workflow_ref}`
 * `job_workflow_ref`: `{job_workflow_ref}`
 * `ref`: `{ref}`
+* `environment`: `{environment}`
 
 See https://docs.pypi.org/trusted-publishers/troubleshooting/ for more help.
 """
@@ -179,6 +180,7 @@ def render_claims(token: str) -> str:
         workflow_ref=_get('workflow_ref'),
         job_workflow_ref=_get('job_workflow_ref'),
         ref=_get('ref'),
+        environment=_get('environment'),
     )
 
 


### PR DESCRIPTION
This includes the `environment` claim when rendering in the TP mismatch error flow.

Closes #334.