### PR TITLE
deps: bump pypi-attestations to 0.0.26

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -13,7 +13,7 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.15
+pypi-attestations ~= 0.0.26
 sigstore ~= 3.5.1
 
 # NOTE: Used to detect the PyPI package name from the distribution files

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -18,7 +18,6 @@ cryptography==43.0.3
     # via
     #   pyopenssl
     #   pypi-attestations
-    #   secretstorage
     #   sigstore
 dnspython==2.7.0
     # via email-validator
@@ -49,10 +48,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
@@ -96,7 +91,7 @@ pyjwt==2.10.1
     # via sigstore
 pyopenssl==25.0.0
     # via sigstore
-pypi-attestations==0.0.21
+pypi-attestations==0.0.26
     # via -r runtime.in
 python-dateutil==2.9.0.post0
     # via betterproto
@@ -123,8 +118,6 @@ rich==13.9.4
     # via
     #   sigstore
     #   twine
-secretstorage==3.3.3
-    # via keyring
 securesystemslib==1.2.0
     # via tuf
 sigstore==3.5.3

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -18,6 +18,7 @@ cryptography==43.0.3
     # via
     #   pyopenssl
     #   pypi-attestations
+    #   secretstorage
     #   sigstore
 dnspython==2.7.0
     # via email-validator
@@ -48,6 +49,10 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
@@ -118,6 +123,8 @@ rich==13.9.4
     # via
     #   sigstore
     #   twine
+secretstorage==3.3.3
+    # via keyring
 securesystemslib==1.2.0
     # via tuf
 sigstore==3.5.3


### PR DESCRIPTION
This should be a non-functional change -- the main relevant thing is does is land https://github.com/trailofbits/pypi-attestations/pull/124, which relaxes the distribution name check a bit (since the previous "ultranormalization" check was much stricter than `packaging` currently enforces or is required by PEP 740).

xref https://github.com/pypi/warehouse/issues/18128 for some more context on the situation that spurred this.

CC @di for viz 🙂 