### PR TITLE
Skip directories when showing hash values

### DIFF
--- a/print-hash.py
+++ b/print-hash.py
@@ -7,6 +7,9 @@ packages_dir = pathlib.Path(sys.argv[1]).resolve()
 print('Showing hash values of files to be uploaded:')
 
 for file_object in packages_dir.iterdir():
+    if file_object.is_dir():
+        continue
+
     sha256 = hashlib.sha256()
     md5 = hashlib.md5()  # noqa: S324; only use for reference
     blake2_256 = hashlib.blake2b(digest_size=256 // 8)


### PR DESCRIPTION
Hi,

I encountered a case where the script failed due to the presence of `.github` directory. 
The rest of the action appears to handle directories appropriately, this part of the script doesn't.

This change is a short-term workaround. Ideally, the implementation should pass the artifacts explicitly rather than relying on iterdir().

Example
```python-traceback
 Showing hash values of files to be uploaded:
/github/workspace/beaker_client-29.2-py3-none-any.whl

SHA256: 955b7a28b414818c450cdab6454a8dff99158e7b26ba2ab7f3bfb6809c948753
MD5: c98c5f772996268d337c229ebe96a94f
BLAKE2-256: b4e114f6f5a388f4e4db41b45bf2ff3c666242284a661c41b5725a08072cf990

/github/workspace/beaker_client-29.2-py3-none-any.whl.publish.attestation

Traceback (most recent call last):
SHA256: bb0b36aa46dbf9406ac41415249b6d5fe674d6c31d8ca2ab0dcfbcd037b41091
MD5: af075233cf503167a0d88027dc02af12
BLAKE2-256: 487b7f3dde89b965a7c22edddb3cf8f57d89f537e26c55f354fd60082d6bcc74

/github/workspace/.github

  File "/app/print-hash.py", line 17, in <module>
    content = file_object.read_bytes()
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 1019, in read_bytes
    with self.open(mode='rb') as f:
         ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 1013, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/github/workspace/.github'
```