### PR TITLE
Do not enable attestations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ filter to the job:
 > Generating and uploading digital attestations currently requires
 > authentication with a [trusted publisher].
 
-To enable the generation of [digital attestations] for all the distribution 
+To enable the generation of [digital attestations] for all the distribution
 files and uploading them along with these, set `attestations` as follows:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ filter to the job:
 > Generating and uploading digital attestations currently requires
 > authentication with a [trusted publisher].
 
-Generating signed [digital attestations] for all the distribution files
-and uploading them all together is now on by default for all projects
-using Trusted Publishing. To disable it, set `attestations` as follows:
+To enable the generation of [digital attestations] for all the distribution 
+files and uploading them along with these, set `attestations` as follows:
 
 ```yml
    with:

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ inputs:
       Enable experimental support for PEP 740 attestations.
       Only works with PyPI and TestPyPI via Trusted Publishing.
     required: false
-    default: 'true'
+    default: 'false'
 branding:
   color: yellow
   icon: upload-cloud


### PR DESCRIPTION
This proposes to revert the default to create attestations.
The documentation clearly states that it is an experimental
feature, while #365 demonstrates that it isn't a fully
evolved functionality, and it randomly breaks publishing
pipelines.
