### PR TITLE
Pin actions/setup-python to a hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,8 @@ runs:
   - name: Install Python 3
     if: steps.pre-installed-python.outputs.python-path == ''
     id: new-python
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    # v5.6.0
+    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
     with:
       python-version: 3.x
   - name: Create Docker container action

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
   - name: Install Python 3
     if: steps.pre-installed-python.outputs.python-path == ''
     id: new-python
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
     with:
       python-version: 3.x
   - name: Create Docker container action

--- a/action.yml
+++ b/action.yml
@@ -139,8 +139,8 @@ runs:
   - name: Install Python 3
     if: steps.pre-installed-python.outputs.python-path == ''
     id: new-python
-    # v5.6.0
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+    # yamllint disable-line rule:line-length
+    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
     with:
       python-version: 3.x
   - name: Create Docker container action

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
   - name: Install Python 3
     if: steps.pre-installed-python.outputs.python-path == ''
     id: new-python
-    uses: actions/setup-python@v5
+    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
     with:
       python-version: 3.x
   - name: Create Docker container action


### PR DESCRIPTION
GitHub has recently added support for requiring pinning hashes in actions (https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/, https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This is more secure - tags can be modified - and prevents CI from breaking on a bad update. 

The policy applies transitively to all used actions, which breaks this action when the policy is enabled (https://github.com/astral-sh/uv/actions/runs/17008660079/job/48221734296). This PR switches to using a hash for the action, solving this. 

If desired, renovate can be configured to update the hash in regular intervals (`pinDigests: true`)