### PR TITLE
deps: bump sigstore and pypi-attestations

### DIFF
--- a/attestations.py
+++ b/attestations.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from pypi_attestations import Attestation, Distribution
+from sigstore.models import ClientTrustConfig
 from sigstore.oidc import IdentityError, IdentityToken, detect_credential
 from sigstore.sign import Signer, SigningContext
 
@@ -141,7 +142,7 @@ def main() -> None:
         # since permissions can't be to blame at this stage.
         die(_TOKEN_RETRIEVAL_FAILED_MESSAGE.format(identity_error=identity_error))
 
-    with SigningContext.production().signer(identity, cache=True) as signer:
+    with SigningContext.from_trust_config(ClientTrustConfig.production()).signer(identity, cache=True) as signer:
         debug(f'attesting to dists: {dist_to_attestation_map.keys()}')
         for dist_path, attestation_path in dist_to_attestation_map.items():
             attest_dist(dist_path, attestation_path, signer)

--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -13,8 +13,8 @@ id ~= 1.0
 requests
 
 # NOTE: Used to generate attestations.
-pypi-attestations ~= 0.0.27
-sigstore ~= 3.6.5
+pypi-attestations ~= 0.0.29
+sigstore ~= 4.1
 
 # NOTE: Used to detect the PyPI package name from the distribution files
 packaging

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,8 +6,6 @@
 #
 annotated-types==0.7.0
     # via pydantic
-betterproto==2.0.0b6
-    # via sigstore-protobuf-specs
 certifi==2025.8.3
     # via requests
 cffi==1.17.1
@@ -19,7 +17,6 @@ cryptography==45.0.7
     #   pyopenssl
     #   pypi-attestations
     #   rfc3161-client
-    #   secretstorage
     #   sigstore
 dnspython==2.7.0
     # via email-validator
@@ -27,14 +24,6 @@ docutils==0.22
     # via readme-renderer
 email-validator==2.3.0
     # via pydantic
-grpclib==0.4.8
-    # via betterproto
-h2==4.3.0
-    # via grpclib
-hpack==4.1.0
-    # via h2
-hyperframe==6.1.0
-    # via h2
 id==1.5.0
     # via
     #   -r runtime.in
@@ -50,10 +39,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==25.6.0
     # via twine
 markdown-it-py==4.0.0
@@ -64,8 +49,6 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-multidict==6.6.4
-    # via grpclib
 nh3==0.3.0
     # via readme-renderer
 packaging==25.0
@@ -86,6 +69,7 @@ pydantic==2.11.7
     # via
     #   pypi-attestations
     #   sigstore
+    #   sigstore-models
     #   sigstore-rekor-types
 pydantic-core==2.33.2
     # via pydantic
@@ -97,10 +81,8 @@ pyjwt==2.10.1
     # via sigstore
 pyopenssl==25.1.0
     # via sigstore
-pypi-attestations==0.0.27
+pypi-attestations==0.0.29
     # via -r runtime.in
-python-dateutil==2.9.0.post0
-    # via betterproto
 readme-renderer==44.0
     # via twine
 requests==2.32.5
@@ -125,22 +107,18 @@ rich==14.1.0
     # via
     #   sigstore
     #   twine
-secretstorage==3.3.3
-    # via keyring
 securesystemslib==1.3.0
     # via tuf
-sigstore==3.6.5
+sigstore==4.1.0
     # via
     #   -r runtime.in
     #   pypi-attestations
-sigstore-protobuf-specs==0.3.2
+sigstore-models==0.0.5
     # via
     #   pypi-attestations
     #   sigstore
 sigstore-rekor-types==0.0.18
     # via sigstore
-six==1.17.0
-    # via python-dateutil
 tuf==6.0.0
     # via sigstore
 twine==6.1.0
@@ -149,6 +127,7 @@ typing-extensions==4.15.0
     # via
     #   pydantic
     #   pydantic-core
+    #   sigstore-models
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic


### PR DESCRIPTION
This serves two purposes:

1. It keeps us on the latest sigstore-python version (and pypi-attestations version), which brings a nice reduction in our dep footprint;
2. It hopefully unblocks #388 by flushing pre-commit.ci's cache.