### PR TITLE
Enable `verbose` and `print-hash` by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
   verbose:
     description: Show verbose output.
     required: false
-    default: 'false'
+    default: 'true'
   print-hash:  # Canonical alias for `print_hash`
     description: Show hash values of files to be uploaded
     required: false
@@ -79,7 +79,7 @@ inputs:
       The inputs have been normalized to use kebab-case.
       Use `print-hash` instead.
     required: false
-    default: 'false'
+    default: 'true'
   attestations:
     description: >-
       Enable support for PEP 740 attestations.


### PR DESCRIPTION
In a CI context, logs are captured and made viewable in a way that does not benefit from hiding them behind a flag.

See #396.