### PR TITLE
Output hashes from github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,13 +68,13 @@ inputs:
     required: false
     default: 'true'
   print-hash:  # Canonical alias for `print_hash`
-    description: Show hash values of files to be uploaded
+    description: Show hash values of uploaded files
     required: false
     # default: 'false'  # TODO: uncomment once alias removed
   print_hash:  # DEPRECATED ALIAS; TODO: Remove in v3+
     description: >-
       [DEPRECATED]
-      Show hash values of files to be uploaded
+      Show hash values of uploaded files
     deprecationMessage: >-
       The inputs have been normalized to use kebab-case.
       Use `print-hash` instead.
@@ -86,6 +86,10 @@ inputs:
       Only works with PyPI and TestPyPI via Trusted Publishing.
     required: false
     default: 'true'
+outputs:
+  hashes:
+    description: Hash values of uploaded files
+    value: ${{ steps.rundocker.outputs.hashes }}
 branding:
   color: yellow
   icon: upload-cloud
@@ -154,6 +158,7 @@ runs:
         }}
     shell: bash
   - name: Run Docker container
+    id: rundocker
     # The generated trampoline action must exist in the allowlisted
     # runner-defined working directory so it can be referenced by the
     # relative path starting with `./`.
@@ -174,5 +179,19 @@ runs:
       verify-metadata: ${{ inputs.verify-metadata || inputs.verify_metadata }}
       skip-existing: ${{ inputs.skip-existing || inputs.skip_existing }}
       verbose: ${{ inputs.verbose }}
-      print-hash: ${{ inputs.print-hash || inputs.print_hash }}
       attestations: ${{ inputs.attestations }}
+  - name: Print hashes
+    if: inputs.print-hash || inputs.print_hash
+    run: |
+      echo -n ${{ steps.rundocker.outputs.hashes }} | mapfile -d '' HASHES
+      echo Showing hash values of uploaded files:
+      for HASH in "${HASHES[@]}" ; do
+        IFS=":" read -r SHA256 MD5 BLAKE2_256 FILE_OBJECT
+        echo $FILE_OBJECT
+        echo
+        echo SHA256: $SHA256
+        echo MD5: $MD5
+        echo BLAKE2-256: $BLAKE_256
+        echo
+      done
+    shell: bash

--- a/create-docker-action.py
+++ b/create-docker-action.py
@@ -53,16 +53,17 @@ action = {
             REQUIRED: False,
         },
         'verbose': {DESCRIPTION: 'Show verbose output.', REQUIRED: False},
-        'print-hash': {
-            DESCRIPTION: 'Show hash values of files to be uploaded',
-            REQUIRED: False,
-        },
         'attestations': {
             DESCRIPTION: (
                 ' Enable support for PEP 740 attestations.'
                 ' Only works with PyPI and TestPyPI via Trusted Publishing.'
             ),
             REQUIRED: False,
+        },
+    },
+    'outputs': {
+        'hashes': {
+            DESCRIPTION: 'Hash values of uploaded files',
         },
     },
     'runs': {

--- a/print-hash.py
+++ b/print-hash.py
@@ -4,15 +4,10 @@ import sys
 
 packages_dir = pathlib.Path(sys.argv[1]).resolve()
 
-print('Showing hash values of files to be uploaded:')
-
 for file_object in packages_dir.iterdir():
     sha256 = hashlib.sha256()
     md5 = hashlib.md5()  # noqa: S324; only use for reference
     blake2_256 = hashlib.blake2b(digest_size=256 // 8)
-
-    print(file_object)
-    print('')
 
     content = file_object.read_bytes()
 
@@ -20,7 +15,14 @@ for file_object in packages_dir.iterdir():
     md5.update(content)
     blake2_256.update(content)
 
-    print(f'SHA256: {sha256.hexdigest()}')
-    print(f'MD5: {md5.hexdigest()}')
-    print(f'BLAKE2-256: {blake2_256.hexdigest()}')
-    print('')
+    print(
+        ":".join(
+            (
+                sha256.hexdigest(),
+                md5.hexdigest(),
+                blake2_256.hexdigest(),
+                file_object.name,
+            ),
+        ),
+        end="\0",
+    )

--- a/twine-upload.sh
+++ b/twine-upload.sh
@@ -204,9 +204,8 @@ if [[ ${INPUT_ATTESTATIONS,,} != "false" ]] ; then
     TWINE_EXTRA_ARGS="--attestations $TWINE_EXTRA_ARGS"
 fi
 
-if [[ ${INPUT_PRINT_HASH,,} != "false" || ${INPUT_VERBOSE,,} != "false" ]] ; then
-    python /app/print-hash.py ${INPUT_PACKAGES_DIR%%/}
-fi
+echo -n "hashes=" >> ${GITHUB_OUTPUT}
+python /app/print-hash.py ${INPUT_PACKAGES_DIR%%/} >> ${GITHUB_OUTPUT}
 
 TWINE_USERNAME="$INPUT_USER" \
 TWINE_PASSWORD="$INPUT_PASSWORD" \


### PR DESCRIPTION
It's useful to have the hashes as outputs so this can be used for [secure installs](https://pip.pypa.io/en/stable/topics/secure-installs/)