### PR TITLE
fix: pin 1 unpinned action(s),extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
       with:
         jobs: ${{ toJSON(needs) }}
 
@@ -73,8 +73,10 @@ jobs:
         DOCKER_TAG: ${{ inputs.tag || github.ref_name }}
     - name: Log in to GHCR
       run: >-
-        echo ${{ secrets.GITHUB_TOKEN }} |
+        echo "${GITHUB_TOKEN}" |
           docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Push Docker image to GHCR
       run: |
         docker push $IMAGE


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning a third-party GitHub Action to an immutable commit SHA and extracting a secret from a `run:` block into an `env:` mapping.

### Why this matters

The build-and-push workflow references `re-actors/alls-green@release/v1` on a mutable tag in a pipeline that has `packages: write` permission to your container registry.

Over the last 5 weeks I've been tracking a nation state actor targeting maintainers of high profile open source projects through social engineering campaigns designed to compromise their accounts. The attack pattern we've seen with tj-actions, Trivy, and Axios all followed the same vector: compromise a maintainer account, force-push malicious code to a mutable tag, and every downstream project silently executes the attacker's code.

If the `re-actors/alls-green` maintainer account were compromised, the attacker could replace what `release/v1` points to. Their modified action would then execute in this workflow with write access to your package registry. Pinning to the commit SHA prevents this because a pinned hash cannot be moved even if the upstream account is compromised.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `build-and-push-docker-image.yml` | Pinned 1 action to commit SHA |
| RGS-008 | high | `build-and-push-docker-image.yml` | Extracted `secrets.GITHUB_TOKEN` from docker login run block to env mapping |

### How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@release/v1` becomes `action@abc123 # release/v1` - original ref preserved as comment
- **Secret extraction**: `${{ secrets.GITHUB_TOKEN }}` moves from the `run:` block to an `env:` mapping, preventing shell interpretation
- No workflow logic, triggers, or permissions are modified

I've had 29 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))