### PR TITLE
fix: container reference lost when using workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,20 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 ```
 
-> [!NOTE]
-> Pro tip: instead of using branch pointers, like `unstable/v1`, pin versions of
-> Actions that you use to tagged versions or sha1 commit identifiers.
-> This will make your workflows more secure and more reproducible, saving you
-> from sudden and unpleasant surprises.
+### Pinning to a commit SHA
+
+```yaml
+- name: Publish package distributions to PyPI
+  uses: pypa/gh-action-pypi-publish@<full-commit-sha>  # release/v1
+  with:
+    use-canonical-image: true
+```
+
+> [!IMPORTANT]
+> When pinning by SHA, set `use-canonical-image: true`. By default it will
+> look for ghcr.io/{username}/{repo}@{branch}
+> `use-canonical-image` forces the canonical
+> `ghcr.io/pypa/gh-action-pypi-publish:release-v1` image.
 
 Other indices that support trusted publishing can also be used, like TestPyPI:
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,8 @@ tag, or opt-in to [use a full Git commit SHA] and Dependabot.
 ### Trusted Publishing
 
 > [!NOTE]
-> Trusted publishing cannot be used from within a reusable workflow at this
-> time. It is recommended to instead create a non-reusable workflow that contains a
-> job calling your reusable workflow, and then do the trusted publishing step from
-> a separate job within that non-reusable workflow. Alternatively, you can still
-> use a username/token inside the reusable workflow.
+> If using trusted published from a workflow, the action needs to be invoked with
+> `use-canonical-image: true`.
 
 > [!NOTE]
 > Trusted Publishing is sometimes referred to by its

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,16 @@ inputs:
       Only works with PyPI and TestPyPI via Trusted Publishing.
     required: false
     default: 'true'
+  use-canonical-image:
+    description: >-
+      Pull the prebuilt Docker image from the canonical
+      `ghcr.io/pypa/gh-action-pypi-publish:release-v1` reference instead of
+      resolving it from the workflow context. Use this when pinning the
+      action by commit SHA or invoking it through another composite action,
+      where `github.action_repository` may resolve to the caller's repo
+      and break image resolution.
+    required: false
+    default: 'false'
 branding:
   color: yellow
   icon: upload-cloud
@@ -152,6 +162,7 @@ runs:
           github.event.pull_request.base.repo.id
           || github.repository_id
         }}
+      USE_CANONICAL_IMAGE: ${{ inputs.use-canonical-image }}
     shell: bash
   - name: Run Docker container
     # The generated trampoline action must exist in the allowlisted

--- a/create-docker-action.py
+++ b/create-docker-action.py
@@ -8,12 +8,16 @@ REQUIRED = 'required'
 REF = os.environ['REF']
 REPO = os.environ['REPO']
 REPO_ID = os.environ['REPO_ID']
+USE_CANONICAL_IMAGE = os.environ.get('USE_CANONICAL_IMAGE', '').lower() == 'true'
 REPO_ID_GH_ACTION = '178055147'
+CANONICAL_IMAGE = 'docker://ghcr.io/pypa/gh-action-pypi-publish:release-v1'
 
 ACTION_SHELL_CHECKOUT_PATH = pathlib.Path(__file__).parent.resolve()
 
 
 def set_image(ref: str, repo: str, repo_id: str) -> str:
+    if USE_CANONICAL_IMAGE:
+        return CANONICAL_IMAGE
     if repo_id == REPO_ID_GH_ACTION:
         return str(ACTION_SHELL_CHECKOUT_PATH / 'Dockerfile')
     docker_ref = ref.replace('/', '-')


### PR DESCRIPTION
Greetings! 

Encountered an issue while trying to set up this action on one of our repos. We referenced it from a workflow via:

```
- name: Publish to PyPI
        if: ${{ inputs.test == 'false' }}
        uses: pypa/gh-action-pypi-publish@<SHA>
        with:
          packages-dir: ${{ inputs.working-directory }}/dist
```
However when we do that we get an issue when it goes to build the docker image.

```
Unable to find image 'ghcr.io/{owner}/{repo}:{branch}' locally
docker: Error response from daemon: Head "https://ghcr.io/v2/{owner}/{repo}/manifests/{branch}": denied
```
I then decided to read the README, and noticed the note about trusted publishing not working. 

From what I could tell from reading through the code, us referencing this by SHA, and the internal reference to the create docker action in `action.yml` via sha, means it loses concept, and the action rather than using this repo, uses the repo it is called from. I think it makes sense to have a canonical image to build via, that can be defaulted to false, but if set to enabled this can be used from a workflow. 

Feel free to change anything, especially the readme! 

Thanks :) 
