### PR TITLE
Bump actions/setup-python from v5.6.0 to v6.2.0 (Node 20 → Node 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
     if: steps.pre-installed-python.outputs.python-path == ''
     id: new-python
     # yamllint disable-line rule:line-length
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
     with:
       python-version: 3.x
   - name: Create Docker container action


### PR DESCRIPTION
## Summary
- GitHub now emits a Node 20 deprecation warning when this action runs, because `action.yml` pins `actions/setup-python@v5.6.0`, which uses the Node 20 runtime.
- [setup-python v6.0.0](https://github.com/actions/setup-python/releases/tag/v6.0.0) upgraded the action's runtime to Node 24. Bumping to the latest pin `v6.2.0` (commit `a309ff8`) removes the warning.
- This is the only Node-based action in the user-facing code path. The other `uses:` reference in `action.yml` is the dynamically-generated Docker container action, which is unaffected. Other `actions/checkout` references live only in `.github/workflows/` (this repo's own CI) and are not part of the consumed action.

## Why the warning surfaces even though the step is skipped
The `Install Python 3` step has `if: steps.pre-installed-python.outputs.python-path == ''`, so it's typically skipped on GitHub-hosted runners (Python is pre-installed). However, the runner still resolves every `uses:` reference at workflow start, which is when the Node 20 deprecation warning is emitted — so the warning shows up for consumers regardless. Bumping the pin fixes that.

## Compatibility note
Per the upstream v6.0.0 release notes, `setup-python@v6` requires GitHub Actions runner `v2.327.1` or later. GitHub-hosted runners are well past this; self-hosted runner users should verify.