### PR TITLE
docs: clarify publishable distribution files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ They are typically expected to do this in a _separate GitHub Actions
 CI/CD job_ running before the one where they call this action and having
 restricted privileges.
 
+Only files recognized by Twine as Python distribution packages should be
+present in the target directory. This usually means wheels (`*.whl`) and
+source distributions (`*.tar.gz`). Remove application binaries, logs, and
+other build artifacts before publishing, or download the publishable dists
+into a dedicated directory and point `packages-dir` at it.
+
 > [!IMPORTANT]
 > Since this GitHub Action is docker-based, it can only
 > be used from within GNU/Linux based jobs in GitHub Actions CI/CD


### PR DESCRIPTION
## Summary
- clarify that the target upload directory should contain only Twine-recognized Python distribution files
- call out common non-distribution artifacts, such as application binaries and logs, as files to remove before publishing
- suggest using a dedicated directory with `packages-dir` when needed

## Checks
- `pre-commit run trailing-whitespace --files README.md`
- `pre-commit run end-of-file-fixer --files README.md`
- `pre-commit run mixed-line-ending --files README.md`
- `pre-commit run codespell --files README.md`