### PR TITLE
Emphasize skip-existing risks

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,13 @@ default) setting as follows:
      skip-existing: true
 ```
 
-> [!NOTE]
-> Pro tip: try to avoid enabling this setting where possible. If you
-> have steps for publishing to both PyPI and TestPyPI, consider only using
-> it for the latter, having the former fail loudly on duplicates.
+> [!WARNING]
+> Avoid enabling `skip-existing` unless your release process intentionally
+> tolerates duplicate files. Duplicate upload errors can signal real release
+> problems, such as publishing the same version twice, reusing stale files, or
+> racing multiple workflows against the same distribution. If you publish to
+> both PyPI and TestPyPI, consider using `skip-existing` only for TestPyPI and
+> letting the PyPI upload fail loudly on duplicates.
 
 ### For Debugging
 


### PR DESCRIPTION
﻿## Summary

- promote the `skip-existing` note to a warning
- call out that duplicate upload errors can indicate real release problems
- recommend keeping PyPI uploads loud while limiting `skip-existing` to duplicate-prone secondary indexes such as TestPyPI

Closes pypa/gh-action-pypi-publish#200

## Verification

- `git diff --check`
- `pre-commit run trailing-whitespace --files README.md`
- `pre-commit run end-of-file-fixer --files README.md`
- `pre-commit run mixed-line-ending --files README.md`
- `pre-commit run codespell --files README.md`
