### PR TITLE
Update twine to v7

### DIFF
--- a/requirements/runtime.in
+++ b/requirements/runtime.in
@@ -1,7 +1,7 @@
 -c runtime-constraints.in  # limits known broken versions
 
-# NOTE: v6.1 is needed to support metadata v2.4 including PEP 639
-twine >= 6.1
+# NOTE: v7 is needed to support metadata v2.5 including PEP 794
+twine >= 7
 
 # NOTE: Used to detect an ambient OIDC credential for OIDC publishing,
 # NOTE: as well as PEP 740 attestations.

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -17,6 +17,7 @@ cryptography==45.0.7
     #   pyopenssl
     #   pypi-attestations
     #   rfc3161-client
+    #   secretstorage
     #   sigstore
 dnspython==2.7.0
     # via email-validator
@@ -39,6 +40,10 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 keyring==25.6.0
     # via twine
 markdown-it-py==4.0.0
@@ -51,7 +56,7 @@ more-itertools==10.8.0
     #   jaraco-functools
 nh3==0.3.0
     # via readme-renderer
-packaging==25.0
+packaging==26.2
     # via
     #   -c runtime-constraints.in
     #   -r runtime.in
@@ -103,10 +108,12 @@ rfc3986==2.0.0
     #   twine
 rfc8785==0.1.4
     # via sigstore
-rich==14.1.0
+rich==14.3.4
     # via
     #   sigstore
     #   twine
+secretstorage==3.5.0
+    # via keyring
 securesystemslib==1.3.0
     # via tuf
 sigstore==4.1.0
@@ -121,7 +128,7 @@ sigstore-rekor-types==0.0.18
     # via sigstore
 tuf==6.0.0
     # via sigstore
-twine==6.1.0
+twine==7.0.0
     # via -r runtime.in
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
Twine 7.0, which was just released, is required for uploading packages with [`Import-Name` metadata](https://peps.python.org/pep-0794/), i.e. metadata version 2.5.